### PR TITLE
lexer: add start,end to token attrs

### DIFF
--- a/src/snapshots/enderpy__lexer__tests__bytes-literals-0.snap
+++ b/src/snapshots/enderpy__lexer__tests__bytes-literals-0.snap
@@ -5,8 +5,10 @@ description: "b\"hello\""
 [
     Token {
         kind: Bytes,
-        value: String(
+        value: Str(
             "b\"hello\"",
         ),
+        start: 0,
+        end: 8,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__bytes-literals-1.snap
+++ b/src/snapshots/enderpy__lexer__tests__bytes-literals-1.snap
@@ -5,8 +5,10 @@ description: "b\"world\""
 [
     Token {
         kind: Bytes,
-        value: String(
+        value: Str(
             "b\"world\"",
         ),
+        start: 0,
+        end: 8,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__bytes-literals-2.snap
+++ b/src/snapshots/enderpy__lexer__tests__bytes-literals-2.snap
@@ -5,8 +5,10 @@ description: "b\"\""
 [
     Token {
         kind: Bytes,
-        value: String(
+        value: Str(
             "b\"\"",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__bytes-literals-3.snap
+++ b/src/snapshots/enderpy__lexer__tests__bytes-literals-3.snap
@@ -5,18 +5,24 @@ description: "a = b\"hello\""
 [
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "a",
         ),
+        start: 0,
+        end: 1,
     },
     Token {
         kind: Assign,
         value: None,
+        start: 2,
+        end: 3,
     },
     Token {
         kind: Bytes,
-        value: String(
+        value: Str(
             "b\"hello\"",
         ),
+        start: 4,
+        end: 12,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__bytes-literals-4.snap
+++ b/src/snapshots/enderpy__lexer__tests__bytes-literals-4.snap
@@ -5,8 +5,10 @@ description: "b'hello'"
 [
     Token {
         kind: Bytes,
-        value: String(
+        value: Str(
             "b'hello'",
         ),
+        start: 0,
+        end: 8,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__bytes-literals-5.snap
+++ b/src/snapshots/enderpy__lexer__tests__bytes-literals-5.snap
@@ -5,8 +5,10 @@ description: "b\"\"\"hello\"\"\""
 [
     Token {
         kind: Bytes,
-        value: String(
+        value: Str(
             "b\"\"\"hello\"\"\"",
         ),
+        start: 0,
+        end: 12,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__bytes-literals-6.snap
+++ b/src/snapshots/enderpy__lexer__tests__bytes-literals-6.snap
@@ -5,8 +5,10 @@ description: "b'''hello'''"
 [
     Token {
         kind: Bytes,
-        value: String(
+        value: Str(
             "b'''hello'''",
         ),
+        start: 0,
+        end: 12,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__f-string-literals-0.snap
+++ b/src/snapshots/enderpy__lexer__tests__f-string-literals-0.snap
@@ -5,8 +5,10 @@ description: "f\"hello\""
 [
     Token {
         kind: FString,
-        value: String(
+        value: Str(
             "f\"hello\"",
         ),
+        start: 0,
+        end: 8,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__f-string-literals-1.snap
+++ b/src/snapshots/enderpy__lexer__tests__f-string-literals-1.snap
@@ -5,8 +5,10 @@ description: "f\"world\""
 [
     Token {
         kind: FString,
-        value: String(
+        value: Str(
             "f\"world\"",
         ),
+        start: 0,
+        end: 8,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__f-string-literals-2.snap
+++ b/src/snapshots/enderpy__lexer__tests__f-string-literals-2.snap
@@ -5,8 +5,10 @@ description: "f\"\""
 [
     Token {
         kind: FString,
-        value: String(
+        value: Str(
             "f\"\"",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__f-string-literals-3.snap
+++ b/src/snapshots/enderpy__lexer__tests__f-string-literals-3.snap
@@ -5,18 +5,24 @@ description: "a = f\"hello\""
 [
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "a",
         ),
+        start: 0,
+        end: 1,
     },
     Token {
         kind: Assign,
         value: None,
+        start: 2,
+        end: 3,
     },
     Token {
         kind: FString,
-        value: String(
+        value: Str(
             "f\"hello\"",
         ),
+        start: 4,
+        end: 12,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__f-string-literals-4.snap
+++ b/src/snapshots/enderpy__lexer__tests__f-string-literals-4.snap
@@ -5,8 +5,10 @@ description: "f'hello_{var}'"
 [
     Token {
         kind: FString,
-        value: String(
+        value: Str(
             "f'hello_{var}'",
         ),
+        start: 0,
+        end: 14,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__f-string-literals-5.snap
+++ b/src/snapshots/enderpy__lexer__tests__f-string-literals-5.snap
@@ -5,8 +5,10 @@ description: "f\"\"\"hello\"\"\""
 [
     Token {
         kind: FString,
-        value: String(
+        value: Str(
             "f\"\"\"hello\"\"\"",
         ),
+        start: 0,
+        end: 12,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__f-string-literals-6.snap
+++ b/src/snapshots/enderpy__lexer__tests__f-string-literals-6.snap
@@ -5,8 +5,10 @@ description: "f'''hello'''"
 [
     Token {
         kind: FString,
-        value: String(
+        value: Str(
             "f'''hello'''",
         ),
+        start: 0,
+        end: 12,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__identifiers-0.snap
+++ b/src/snapshots/enderpy__lexer__tests__identifiers-0.snap
@@ -5,8 +5,10 @@ description: a
 [
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "a",
         ),
+        start: 0,
+        end: 1,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__identifiers-1.snap
+++ b/src/snapshots/enderpy__lexer__tests__identifiers-1.snap
@@ -5,8 +5,10 @@ description: a_a
 [
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "a_a",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__identifiers-2.snap
+++ b/src/snapshots/enderpy__lexer__tests__identifiers-2.snap
@@ -5,8 +5,10 @@ description: _a
 [
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "_a",
         ),
+        start: 0,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__identifiers-3.snap
+++ b/src/snapshots/enderpy__lexer__tests__identifiers-3.snap
@@ -5,8 +5,10 @@ description: a_
 [
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "a_",
         ),
+        start: 0,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__identifiers-4.snap
+++ b/src/snapshots/enderpy__lexer__tests__identifiers-4.snap
@@ -5,8 +5,10 @@ description: a_a_a
 [
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "a_a_a",
         ),
+        start: 0,
+        end: 5,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__identifiers-5.snap
+++ b/src/snapshots/enderpy__lexer__tests__identifiers-5.snap
@@ -5,8 +5,10 @@ description: a_a_
 [
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "a_a_",
         ),
+        start: 0,
+        end: 4,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__identifiers-6.snap
+++ b/src/snapshots/enderpy__lexer__tests__identifiers-6.snap
@@ -5,8 +5,10 @@ description: ಠ_ಠ
 [
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "ಠ_ಠ",
         ),
+        start: 0,
+        end: 7,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__import-0.snap
+++ b/src/snapshots/enderpy__lexer__tests__import-0.snap
@@ -6,11 +6,15 @@ description: import a
     Token {
         kind: Import,
         value: None,
+        start: 0,
+        end: 6,
     },
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "a",
         ),
+        start: 7,
+        end: 8,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__import-1.snap
+++ b/src/snapshots/enderpy__lexer__tests__import-1.snap
@@ -6,21 +6,29 @@ description: import a.b
     Token {
         kind: Import,
         value: None,
+        start: 0,
+        end: 6,
     },
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "a",
         ),
+        start: 7,
+        end: 8,
     },
     Token {
         kind: Dot,
         value: None,
+        start: 8,
+        end: 9,
     },
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "b",
         ),
+        start: 9,
+        end: 10,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__import-2.snap
+++ b/src/snapshots/enderpy__lexer__tests__import-2.snap
@@ -6,31 +6,43 @@ description: import a.b.c
     Token {
         kind: Import,
         value: None,
+        start: 0,
+        end: 6,
     },
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "a",
         ),
+        start: 7,
+        end: 8,
     },
     Token {
         kind: Dot,
         value: None,
+        start: 8,
+        end: 9,
     },
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "b",
         ),
+        start: 9,
+        end: 10,
     },
     Token {
         kind: Dot,
         value: None,
+        start: 10,
+        end: 11,
     },
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "c",
         ),
+        start: 11,
+        end: 12,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__import-3.snap
+++ b/src/snapshots/enderpy__lexer__tests__import-3.snap
@@ -6,21 +6,29 @@ description: import a from b
     Token {
         kind: Import,
         value: None,
+        start: 0,
+        end: 6,
     },
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "a",
         ),
+        start: 7,
+        end: 8,
     },
     Token {
         kind: From,
         value: None,
+        start: 9,
+        end: 13,
     },
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "b",
         ),
+        start: 14,
+        end: 15,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__indentation-0.snap
+++ b/src/snapshots/enderpy__lexer__tests__indentation-0.snap
@@ -6,27 +6,39 @@ description: "if True:\n            pass"
     Token {
         kind: If,
         value: None,
+        start: 0,
+        end: 2,
     },
     Token {
         kind: True,
         value: None,
+        start: 3,
+        end: 7,
     },
     Token {
         kind: Colon,
         value: None,
+        start: 7,
+        end: 8,
     },
     Token {
         kind: NewLine,
         value: None,
+        start: 8,
+        end: 9,
     },
     Token {
         kind: Indent,
         value: Indent(
             1,
         ),
+        start: 9,
+        end: 21,
     },
     Token {
         kind: Pass,
         value: None,
+        start: 21,
+        end: 25,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__indentation-1.snap
+++ b/src/snapshots/enderpy__lexer__tests__indentation-1.snap
@@ -6,59 +6,85 @@ description: "if True:\n    pass\nelse:\n    pass"
     Token {
         kind: If,
         value: None,
+        start: 0,
+        end: 2,
     },
     Token {
         kind: True,
         value: None,
+        start: 3,
+        end: 7,
     },
     Token {
         kind: Colon,
         value: None,
+        start: 7,
+        end: 8,
     },
     Token {
         kind: NewLine,
         value: None,
+        start: 8,
+        end: 9,
     },
     Token {
         kind: Indent,
         value: Indent(
             1,
         ),
+        start: 9,
+        end: 13,
     },
     Token {
         kind: Pass,
         value: None,
+        start: 13,
+        end: 17,
     },
     Token {
         kind: NewLine,
         value: None,
+        start: 17,
+        end: 18,
     },
     Token {
         kind: Dedent,
         value: Indent(
             1,
         ),
+        start: 18,
+        end: 18,
     },
     Token {
         kind: Else,
         value: None,
+        start: 18,
+        end: 22,
     },
     Token {
         kind: Colon,
         value: None,
+        start: 22,
+        end: 23,
     },
     Token {
         kind: NewLine,
         value: None,
+        start: 23,
+        end: 24,
     },
     Token {
         kind: Indent,
         value: Indent(
             1,
         ),
+        start: 24,
+        end: 28,
     },
     Token {
         kind: Pass,
         value: None,
+        start: 28,
+        end: 32,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__indentation-2.snap
+++ b/src/snapshots/enderpy__lexer__tests__indentation-2.snap
@@ -6,63 +6,91 @@ description: "if True:\n    if True:\n        pass\ndef"
     Token {
         kind: If,
         value: None,
+        start: 0,
+        end: 2,
     },
     Token {
         kind: True,
         value: None,
+        start: 3,
+        end: 7,
     },
     Token {
         kind: Colon,
         value: None,
+        start: 7,
+        end: 8,
     },
     Token {
         kind: NewLine,
         value: None,
+        start: 8,
+        end: 9,
     },
     Token {
         kind: Indent,
         value: Indent(
             1,
         ),
+        start: 9,
+        end: 13,
     },
     Token {
         kind: If,
         value: None,
+        start: 13,
+        end: 15,
     },
     Token {
         kind: True,
         value: None,
+        start: 16,
+        end: 20,
     },
     Token {
         kind: Colon,
         value: None,
+        start: 20,
+        end: 21,
     },
     Token {
         kind: NewLine,
         value: None,
+        start: 21,
+        end: 22,
     },
     Token {
         kind: Indent,
         value: Indent(
             1,
         ),
+        start: 22,
+        end: 30,
     },
     Token {
         kind: Pass,
         value: None,
+        start: 30,
+        end: 34,
     },
     Token {
         kind: NewLine,
         value: None,
+        start: 34,
+        end: 35,
     },
     Token {
         kind: Dedent,
         value: Indent(
             2,
         ),
+        start: 35,
+        end: 35,
     },
     Token {
         kind: Def,
         value: None,
+        start: 35,
+        end: 38,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__keywords-0.snap
+++ b/src/snapshots/enderpy__lexer__tests__keywords-0.snap
@@ -6,33 +6,49 @@ description: False None True and as assert async await
     Token {
         kind: False,
         value: None,
+        start: 0,
+        end: 5,
     },
     Token {
         kind: None,
         value: None,
+        start: 6,
+        end: 10,
     },
     Token {
         kind: True,
         value: None,
+        start: 11,
+        end: 15,
     },
     Token {
         kind: And,
         value: None,
+        start: 16,
+        end: 19,
     },
     Token {
         kind: As,
         value: None,
+        start: 20,
+        end: 22,
     },
     Token {
         kind: Assert,
         value: None,
+        start: 23,
+        end: 29,
     },
     Token {
         kind: Async,
         value: None,
+        start: 30,
+        end: 35,
     },
     Token {
         kind: Await,
         value: None,
+        start: 36,
+        end: 41,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__keywords-1.snap
+++ b/src/snapshots/enderpy__lexer__tests__keywords-1.snap
@@ -6,33 +6,49 @@ description: break class continue def del elif else except
     Token {
         kind: Break,
         value: None,
+        start: 0,
+        end: 5,
     },
     Token {
         kind: Class,
         value: None,
+        start: 6,
+        end: 11,
     },
     Token {
         kind: Continue,
         value: None,
+        start: 12,
+        end: 20,
     },
     Token {
         kind: Def,
         value: None,
+        start: 21,
+        end: 24,
     },
     Token {
         kind: Del,
         value: None,
+        start: 25,
+        end: 28,
     },
     Token {
         kind: Elif,
         value: None,
+        start: 29,
+        end: 33,
     },
     Token {
         kind: Else,
         value: None,
+        start: 34,
+        end: 38,
     },
     Token {
         kind: Except,
         value: None,
+        start: 39,
+        end: 45,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__keywords-2.snap
+++ b/src/snapshots/enderpy__lexer__tests__keywords-2.snap
@@ -6,37 +6,55 @@ description: finally for from global if import in is lambda
     Token {
         kind: Finally,
         value: None,
+        start: 0,
+        end: 7,
     },
     Token {
         kind: For,
         value: None,
+        start: 8,
+        end: 11,
     },
     Token {
         kind: From,
         value: None,
+        start: 12,
+        end: 16,
     },
     Token {
         kind: Global,
         value: None,
+        start: 17,
+        end: 23,
     },
     Token {
         kind: If,
         value: None,
+        start: 24,
+        end: 26,
     },
     Token {
         kind: Import,
         value: None,
+        start: 27,
+        end: 33,
     },
     Token {
         kind: In,
         value: None,
+        start: 34,
+        end: 36,
     },
     Token {
         kind: Is,
         value: None,
+        start: 37,
+        end: 39,
     },
     Token {
         kind: Lambda,
         value: None,
+        start: 40,
+        end: 46,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__keywords-3.snap
+++ b/src/snapshots/enderpy__lexer__tests__keywords-3.snap
@@ -6,41 +6,61 @@ description: nonlocal not or pass raise return try while with yield
     Token {
         kind: Nonlocal,
         value: None,
+        start: 0,
+        end: 8,
     },
     Token {
         kind: Not,
         value: None,
+        start: 9,
+        end: 12,
     },
     Token {
         kind: Or,
         value: None,
+        start: 13,
+        end: 15,
     },
     Token {
         kind: Pass,
         value: None,
+        start: 16,
+        end: 20,
     },
     Token {
         kind: Raise,
         value: None,
+        start: 21,
+        end: 26,
     },
     Token {
         kind: Return,
         value: None,
+        start: 27,
+        end: 33,
     },
     Token {
         kind: Try,
         value: None,
+        start: 34,
+        end: 37,
     },
     Token {
         kind: While,
         value: None,
+        start: 38,
+        end: 43,
     },
     Token {
         kind: With,
         value: None,
+        start: 44,
+        end: 48,
     },
     Token {
         kind: Yield,
         value: None,
+        start: 49,
+        end: 54,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-binary-0.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-binary-0.snap
@@ -8,5 +8,7 @@ description: 0b0
         value: Number(
             "0b0",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-binary-1.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-binary-1.snap
@@ -8,5 +8,7 @@ description: 0b1
         value: Number(
             "0b1",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-binary-2.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-binary-2.snap
@@ -8,5 +8,7 @@ description: 0b10
         value: Number(
             "0b10",
         ),
+        start: 0,
+        end: 4,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-binary-3.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-binary-3.snap
@@ -8,5 +8,7 @@ description: 0b11
         value: Number(
             "0b11",
         ),
+        start: 0,
+        end: 4,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-binary-4.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-binary-4.snap
@@ -8,5 +8,7 @@ description: 0b100
         value: Number(
             "0b100",
         ),
+        start: 0,
+        end: 5,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-binary-5.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-binary-5.snap
@@ -8,5 +8,7 @@ description: 0b101
         value: Number(
             "0b101",
         ),
+        start: 0,
+        end: 5,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-binary-6.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-binary-6.snap
@@ -8,5 +8,7 @@ description: 0b110
         value: Number(
             "0b110",
         ),
+        start: 0,
+        end: 5,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-binary-7.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-binary-7.snap
@@ -8,5 +8,7 @@ description: 0b111
         value: Number(
             "0b111",
         ),
+        start: 0,
+        end: 5,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-floating-exponent-0.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-floating-exponent-0.snap
@@ -8,29 +8,39 @@ description: 0e0 0e-1 0e+2 0e+3j 0e+3J
         value: Number(
             "0e0",
         ),
+        start: 0,
+        end: 3,
     },
     Token {
         kind: ExponentFloat,
         value: Number(
             "0e-1",
         ),
+        start: 4,
+        end: 8,
     },
     Token {
         kind: ExponentFloat,
         value: Number(
             "0e+2",
         ),
+        start: 9,
+        end: 13,
     },
     Token {
         kind: ImaginaryExponentFloat,
         value: Number(
             "0e+3j",
         ),
+        start: 14,
+        end: 19,
     },
     Token {
         kind: ImaginaryExponentFloat,
         value: Number(
             "0e+3J",
         ),
+        start: 20,
+        end: 25,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-floating-point-0.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-floating-point-0.snap
@@ -8,35 +8,47 @@ description: 0.0 0.1 00.0 00.1 0.1j 0.01J
         value: Number(
             "0.0",
         ),
+        start: 0,
+        end: 3,
     },
     Token {
         kind: PointFloat,
         value: Number(
             "0.1",
         ),
+        start: 4,
+        end: 7,
     },
     Token {
         kind: PointFloat,
         value: Number(
             "00.0",
         ),
+        start: 8,
+        end: 12,
     },
     Token {
         kind: PointFloat,
         value: Number(
             "00.1",
         ),
+        start: 13,
+        end: 17,
     },
     Token {
         kind: PointFloat,
         value: Number(
             "0.1j",
         ),
+        start: 18,
+        end: 22,
     },
     Token {
         kind: PointFloat,
         value: Number(
             "0.01J",
         ),
+        start: 23,
+        end: 28,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-0.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-0.snap
@@ -8,5 +8,7 @@ description: "0x0"
         value: Number(
             "0x0",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-1.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-1.snap
@@ -8,5 +8,7 @@ description: "0x1"
         value: Number(
             "0x1",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-10.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-10.snap
@@ -8,5 +8,7 @@ description: "0xa"
         value: Number(
             "0xa",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-11.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-11.snap
@@ -8,5 +8,7 @@ description: "0xb"
         value: Number(
             "0xb",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-12.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-12.snap
@@ -8,5 +8,7 @@ description: "0xc"
         value: Number(
             "0xc",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-13.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-13.snap
@@ -8,5 +8,7 @@ description: "0xd"
         value: Number(
             "0xd",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-14.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-14.snap
@@ -8,5 +8,7 @@ description: "0xe"
         value: Number(
             "0xe",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-15.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-15.snap
@@ -8,5 +8,7 @@ description: "0xf"
         value: Number(
             "0xf",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-16.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-16.snap
@@ -8,5 +8,7 @@ description: "0xA"
         value: Number(
             "0xA",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-17.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-17.snap
@@ -8,5 +8,7 @@ description: "0xB"
         value: Number(
             "0xB",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-18.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-18.snap
@@ -8,5 +8,7 @@ description: "0xC"
         value: Number(
             "0xC",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-19.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-19.snap
@@ -8,5 +8,7 @@ description: "0xD"
         value: Number(
             "0xD",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-2.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-2.snap
@@ -8,5 +8,7 @@ description: "0x2"
         value: Number(
             "0x2",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-20.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-20.snap
@@ -8,5 +8,7 @@ description: "0xE"
         value: Number(
             "0xE",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-21.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-21.snap
@@ -8,5 +8,7 @@ description: "0xF"
         value: Number(
             "0xF",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-3.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-3.snap
@@ -8,5 +8,7 @@ description: "0x3"
         value: Number(
             "0x3",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-4.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-4.snap
@@ -8,5 +8,7 @@ description: "0x4"
         value: Number(
             "0x4",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-5.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-5.snap
@@ -8,5 +8,7 @@ description: "0x5"
         value: Number(
             "0x5",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-6.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-6.snap
@@ -8,5 +8,7 @@ description: "0x6"
         value: Number(
             "0x6",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-7.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-7.snap
@@ -8,5 +8,7 @@ description: "0x7"
         value: Number(
             "0x7",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-8.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-8.snap
@@ -8,5 +8,7 @@ description: "0x8"
         value: Number(
             "0x8",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-9.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-hexadecimal-9.snap
@@ -8,5 +8,7 @@ description: "0x9"
         value: Number(
             "0x9",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-integer-0.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-integer-0.snap
@@ -8,23 +8,31 @@ description: 11 33 1j 1_000_000j
         value: Number(
             "11",
         ),
+        start: 0,
+        end: 2,
     },
     Token {
         kind: Integer,
         value: Number(
             "33",
         ),
+        start: 3,
+        end: 5,
     },
     Token {
         kind: ImaginaryInteger,
         value: Number(
             "1j",
         ),
+        start: 6,
+        end: 8,
     },
     Token {
         kind: ImaginaryInteger,
         value: Number(
             "1_000_000j",
         ),
+        start: 9,
+        end: 19,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-octal-0.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-octal-0.snap
@@ -7,5 +7,7 @@ source: src/lexer.rs
         value: Number(
             "0o0",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-octal-1.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-octal-1.snap
@@ -7,5 +7,7 @@ source: src/lexer.rs
         value: Number(
             "0o1",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-octal-2.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-octal-2.snap
@@ -7,5 +7,7 @@ source: src/lexer.rs
         value: Number(
             "0o2",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-octal-3.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-octal-3.snap
@@ -7,5 +7,7 @@ source: src/lexer.rs
         value: Number(
             "0o3",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-octal-4.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-octal-4.snap
@@ -7,5 +7,7 @@ source: src/lexer.rs
         value: Number(
             "0o4",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-octal-5.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-octal-5.snap
@@ -7,5 +7,7 @@ source: src/lexer.rs
         value: Number(
             "0o5",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-octal-6.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-octal-6.snap
@@ -7,5 +7,7 @@ source: src/lexer.rs
         value: Number(
             "0o6",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__numeric-octal-7.snap
+++ b/src/snapshots/enderpy__lexer__tests__numeric-octal-7.snap
@@ -7,5 +7,7 @@ source: src/lexer.rs
         value: Number(
             "0o7",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__raw-bytes-literals-0.snap
+++ b/src/snapshots/enderpy__lexer__tests__raw-bytes-literals-0.snap
@@ -5,8 +5,10 @@ description: "rb\"hello\""
 [
     Token {
         kind: RawBytes,
-        value: String(
+        value: Str(
             "rb\"hello\"",
         ),
+        start: 0,
+        end: 9,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__raw-bytes-literals-1.snap
+++ b/src/snapshots/enderpy__lexer__tests__raw-bytes-literals-1.snap
@@ -5,8 +5,10 @@ description: "rb\"world\""
 [
     Token {
         kind: RawBytes,
-        value: String(
+        value: Str(
             "rb\"world\"",
         ),
+        start: 0,
+        end: 9,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__raw-bytes-literals-2.snap
+++ b/src/snapshots/enderpy__lexer__tests__raw-bytes-literals-2.snap
@@ -5,8 +5,10 @@ description: "rb\"\""
 [
     Token {
         kind: RawBytes,
-        value: String(
+        value: Str(
             "rb\"\"",
         ),
+        start: 0,
+        end: 4,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__raw-bytes-literals-3.snap
+++ b/src/snapshots/enderpy__lexer__tests__raw-bytes-literals-3.snap
@@ -5,18 +5,24 @@ description: "a = rb\"hello\""
 [
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "a",
         ),
+        start: 0,
+        end: 1,
     },
     Token {
         kind: Assign,
         value: None,
+        start: 2,
+        end: 3,
     },
     Token {
         kind: RawBytes,
-        value: String(
+        value: Str(
             "rb\"hello\"",
         ),
+        start: 4,
+        end: 13,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__raw-bytes-literals-4.snap
+++ b/src/snapshots/enderpy__lexer__tests__raw-bytes-literals-4.snap
@@ -5,8 +5,10 @@ description: "rb'hello'"
 [
     Token {
         kind: RawBytes,
-        value: String(
+        value: Str(
             "rb'hello'",
         ),
+        start: 0,
+        end: 9,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__raw-bytes-literals-5.snap
+++ b/src/snapshots/enderpy__lexer__tests__raw-bytes-literals-5.snap
@@ -5,8 +5,10 @@ description: "rb\"\"\"hello\"\"\""
 [
     Token {
         kind: RawBytes,
-        value: String(
+        value: Str(
             "rb\"\"\"hello\"\"\"",
         ),
+        start: 0,
+        end: 13,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__raw-bytes-literals-6.snap
+++ b/src/snapshots/enderpy__lexer__tests__raw-bytes-literals-6.snap
@@ -5,8 +5,10 @@ description: "rb'''hello'''"
 [
     Token {
         kind: RawBytes,
-        value: String(
+        value: Str(
             "rb'''hello'''",
         ),
+        start: 0,
+        end: 13,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__raw-f-string-literals-0.snap
+++ b/src/snapshots/enderpy__lexer__tests__raw-f-string-literals-0.snap
@@ -5,8 +5,10 @@ description: "rf\"hello\""
 [
     Token {
         kind: RawFString,
-        value: String(
+        value: Str(
             "rf\"hello\"",
         ),
+        start: 0,
+        end: 9,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__raw-f-string-literals-1.snap
+++ b/src/snapshots/enderpy__lexer__tests__raw-f-string-literals-1.snap
@@ -5,8 +5,10 @@ description: "rf\"world\""
 [
     Token {
         kind: RawFString,
-        value: String(
+        value: Str(
             "rf\"world\"",
         ),
+        start: 0,
+        end: 9,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__raw-f-string-literals-2.snap
+++ b/src/snapshots/enderpy__lexer__tests__raw-f-string-literals-2.snap
@@ -5,8 +5,10 @@ description: "rf\"\""
 [
     Token {
         kind: RawFString,
-        value: String(
+        value: Str(
             "rf\"\"",
         ),
+        start: 0,
+        end: 4,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__raw-f-string-literals-3.snap
+++ b/src/snapshots/enderpy__lexer__tests__raw-f-string-literals-3.snap
@@ -5,18 +5,24 @@ description: "a = rf\"hello\""
 [
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "a",
         ),
+        start: 0,
+        end: 1,
     },
     Token {
         kind: Assign,
         value: None,
+        start: 2,
+        end: 3,
     },
     Token {
         kind: RawFString,
-        value: String(
+        value: Str(
             "rf\"hello\"",
         ),
+        start: 4,
+        end: 13,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__raw-f-string-literals-4.snap
+++ b/src/snapshots/enderpy__lexer__tests__raw-f-string-literals-4.snap
@@ -5,8 +5,10 @@ description: "rf'hello_{var}'"
 [
     Token {
         kind: RawFString,
-        value: String(
+        value: Str(
             "rf'hello_{var}'",
         ),
+        start: 0,
+        end: 15,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__raw-f-string-literals-5.snap
+++ b/src/snapshots/enderpy__lexer__tests__raw-f-string-literals-5.snap
@@ -5,8 +5,10 @@ description: "rf\"\"\"hello\"\"\""
 [
     Token {
         kind: RawFString,
-        value: String(
+        value: Str(
             "rf\"\"\"hello\"\"\"",
         ),
+        start: 0,
+        end: 13,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__raw-f-string-literals-6.snap
+++ b/src/snapshots/enderpy__lexer__tests__raw-f-string-literals-6.snap
@@ -5,8 +5,10 @@ description: "rf'''hello'''"
 [
     Token {
         kind: RawFString,
-        value: String(
+        value: Str(
             "rf'''hello'''",
         ),
+        start: 0,
+        end: 13,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__raw-string-literals-0.snap
+++ b/src/snapshots/enderpy__lexer__tests__raw-string-literals-0.snap
@@ -5,8 +5,10 @@ description: "r\"hello\""
 [
     Token {
         kind: RawString,
-        value: String(
+        value: Str(
             "r\"hello\"",
         ),
+        start: 0,
+        end: 8,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__raw-string-literals-1.snap
+++ b/src/snapshots/enderpy__lexer__tests__raw-string-literals-1.snap
@@ -5,8 +5,10 @@ description: "r\"world\""
 [
     Token {
         kind: RawString,
-        value: String(
+        value: Str(
             "r\"world\"",
         ),
+        start: 0,
+        end: 8,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__raw-string-literals-2.snap
+++ b/src/snapshots/enderpy__lexer__tests__raw-string-literals-2.snap
@@ -5,8 +5,10 @@ description: "r\"\""
 [
     Token {
         kind: RawString,
-        value: String(
+        value: Str(
             "r\"\"",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__raw-string-literals-3.snap
+++ b/src/snapshots/enderpy__lexer__tests__raw-string-literals-3.snap
@@ -5,18 +5,24 @@ description: "a = r\"hello\""
 [
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "a",
         ),
+        start: 0,
+        end: 1,
     },
     Token {
         kind: Assign,
         value: None,
+        start: 2,
+        end: 3,
     },
     Token {
         kind: RawString,
-        value: String(
+        value: Str(
             "r\"hello\"",
         ),
+        start: 4,
+        end: 12,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__raw-string-literals-4.snap
+++ b/src/snapshots/enderpy__lexer__tests__raw-string-literals-4.snap
@@ -5,8 +5,10 @@ description: "r'hello'"
 [
     Token {
         kind: RawString,
-        value: String(
+        value: Str(
             "r'hello'",
         ),
+        start: 0,
+        end: 8,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__raw-string-literals-5.snap
+++ b/src/snapshots/enderpy__lexer__tests__raw-string-literals-5.snap
@@ -5,8 +5,10 @@ description: "r\"\"\"hello\"\"\""
 [
     Token {
         kind: RawString,
-        value: String(
+        value: Str(
             "r\"\"\"hello\"\"\"",
         ),
+        start: 0,
+        end: 12,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__raw-string-literals-6.snap
+++ b/src/snapshots/enderpy__lexer__tests__raw-string-literals-6.snap
@@ -5,8 +5,10 @@ description: "r'''hello'''"
 [
     Token {
         kind: RawString,
-        value: String(
+        value: Str(
             "r'''hello'''",
         ),
+        start: 0,
+        end: 12,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__string-literals-0.snap
+++ b/src/snapshots/enderpy__lexer__tests__string-literals-0.snap
@@ -5,8 +5,10 @@ description: "\"hello\""
 [
     Token {
         kind: StringLiteral,
-        value: String(
+        value: Str(
             "\"hello\"",
         ),
+        start: 0,
+        end: 7,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__string-literals-1.snap
+++ b/src/snapshots/enderpy__lexer__tests__string-literals-1.snap
@@ -5,8 +5,10 @@ description: "\"world\""
 [
     Token {
         kind: StringLiteral,
-        value: String(
+        value: Str(
             "\"world\"",
         ),
+        start: 0,
+        end: 7,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__string-literals-2.snap
+++ b/src/snapshots/enderpy__lexer__tests__string-literals-2.snap
@@ -5,8 +5,10 @@ description: "\"\""
 [
     Token {
         kind: StringLiteral,
-        value: String(
+        value: Str(
             "\"\"",
         ),
+        start: 0,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__string-literals-3.snap
+++ b/src/snapshots/enderpy__lexer__tests__string-literals-3.snap
@@ -5,18 +5,24 @@ description: "a = \"hello\""
 [
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "a",
         ),
+        start: 0,
+        end: 1,
     },
     Token {
         kind: Assign,
         value: None,
+        start: 2,
+        end: 3,
     },
     Token {
         kind: StringLiteral,
-        value: String(
+        value: Str(
             "\"hello\"",
         ),
+        start: 4,
+        end: 11,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__string-literals-4.snap
+++ b/src/snapshots/enderpy__lexer__tests__string-literals-4.snap
@@ -5,8 +5,10 @@ description: "'hello'"
 [
     Token {
         kind: StringLiteral,
-        value: String(
+        value: Str(
             "'hello'",
         ),
+        start: 0,
+        end: 7,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__string-literals-5.snap
+++ b/src/snapshots/enderpy__lexer__tests__string-literals-5.snap
@@ -5,8 +5,10 @@ description: "\"\"\"hello\"\"\""
 [
     Token {
         kind: StringLiteral,
-        value: String(
+        value: Str(
             "\"\"\"hello\"\"\"",
         ),
+        start: 0,
+        end: 11,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__string-literals-6.snap
+++ b/src/snapshots/enderpy__lexer__tests__string-literals-6.snap
@@ -5,8 +5,10 @@ description: "'''hello'''"
 [
     Token {
         kind: StringLiteral,
-        value: String(
+        value: Str(
             "'''hello'''",
         ),
+        start: 0,
+        end: 11,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-0.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-0.snap
@@ -8,15 +8,21 @@ description: 1+2
         value: Number(
             "1",
         ),
+        start: 0,
+        end: 1,
     },
     Token {
         kind: Plus,
         value: None,
+        start: 1,
+        end: 2,
     },
     Token {
         kind: Integer,
         value: Number(
             "2",
         ),
+        start: 2,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-1.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-1.snap
@@ -5,18 +5,24 @@ description: a+b
 [
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "a",
         ),
+        start: 0,
+        end: 1,
     },
     Token {
         kind: Plus,
         value: None,
+        start: 1,
+        end: 2,
     },
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "b",
         ),
+        start: 2,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-10.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-10.snap
@@ -6,5 +6,7 @@ description: ","
     Token {
         kind: Comma,
         value: None,
+        start: 0,
+        end: 1,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-11.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-11.snap
@@ -6,5 +6,7 @@ description: ;
     Token {
         kind: SemiColon,
         value: None,
+        start: 0,
+        end: 1,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-12.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-12.snap
@@ -6,5 +6,7 @@ description: "@"
     Token {
         kind: MatrixMul,
         value: None,
+        start: 0,
+        end: 1,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-13.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-13.snap
@@ -6,5 +6,7 @@ description: "="
     Token {
         kind: Assign,
         value: None,
+        start: 0,
+        end: 1,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-14.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-14.snap
@@ -6,5 +6,7 @@ description: "\\"
     Token {
         kind: BackSlash,
         value: None,
+        start: 0,
+        end: 1,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-15.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-15.snap
@@ -6,5 +6,7 @@ description: "#"
     Token {
         kind: Sharp,
         value: None,
+        start: 0,
+        end: 1,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-16.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-16.snap
@@ -6,5 +6,7 @@ description: $
     Token {
         kind: Dollar,
         value: None,
+        start: 0,
+        end: 1,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-17.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-17.snap
@@ -6,5 +6,7 @@ description: "?"
     Token {
         kind: QuestionMark,
         value: None,
+        start: 0,
+        end: 1,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-18.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-18.snap
@@ -6,5 +6,7 @@ description: "`"
     Token {
         kind: BackTick,
         value: None,
+        start: 0,
+        end: 1,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-19.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-19.snap
@@ -6,5 +6,7 @@ description: "->"
     Token {
         kind: Arrow,
         value: None,
+        start: 0,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-2.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-2.snap
@@ -5,18 +5,24 @@ description: a + b
 [
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "a",
         ),
+        start: 0,
+        end: 1,
     },
     Token {
         kind: Plus,
         value: None,
+        start: 2,
+        end: 3,
     },
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "b",
         ),
+        start: 4,
+        end: 5,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-20.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-20.snap
@@ -6,5 +6,7 @@ description: +=
     Token {
         kind: AddAssign,
         value: None,
+        start: 0,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-21.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-21.snap
@@ -6,5 +6,7 @@ description: "-="
     Token {
         kind: SubAssign,
         value: None,
+        start: 0,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-22.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-22.snap
@@ -6,5 +6,7 @@ description: "*="
     Token {
         kind: MulAssign,
         value: None,
+        start: 0,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-23.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-23.snap
@@ -6,5 +6,7 @@ description: /=
     Token {
         kind: DivAssign,
         value: None,
+        start: 0,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-24.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-24.snap
@@ -6,5 +6,7 @@ description: "%="
     Token {
         kind: ModAssign,
         value: None,
+        start: 0,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-25.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-25.snap
@@ -6,5 +6,7 @@ description: "@="
     Token {
         kind: MatrixMulAssign,
         value: None,
+        start: 0,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-26.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-26.snap
@@ -6,5 +6,7 @@ description: "&="
     Token {
         kind: BitAndAssign,
         value: None,
+        start: 0,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-27.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-27.snap
@@ -6,5 +6,7 @@ description: "|="
     Token {
         kind: BitOrAssign,
         value: None,
+        start: 0,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-28.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-28.snap
@@ -6,5 +6,7 @@ description: ^=
     Token {
         kind: BitXorAssign,
         value: None,
+        start: 0,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-29.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-29.snap
@@ -6,5 +6,7 @@ description: //=
     Token {
         kind: IntDivAssign,
         value: None,
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-3.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-3.snap
@@ -6,11 +6,15 @@ description: +=2
     Token {
         kind: AddAssign,
         value: None,
+        start: 0,
+        end: 2,
     },
     Token {
         kind: Integer,
         value: Number(
             "2",
         ),
+        start: 2,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-30.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-30.snap
@@ -6,5 +6,7 @@ description: "<<="
     Token {
         kind: ShiftLeftAssign,
         value: None,
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-31.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-31.snap
@@ -6,5 +6,7 @@ description: ">>="
     Token {
         kind: ShiftRightAssign,
         value: None,
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-32.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-32.snap
@@ -6,5 +6,7 @@ description: "**="
     Token {
         kind: PowAssign,
         value: None,
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-33.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-33.snap
@@ -6,5 +6,7 @@ description: "**"
     Token {
         kind: Pow,
         value: None,
+        start: 0,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-34.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-34.snap
@@ -6,5 +6,7 @@ description: //
     Token {
         kind: IntDiv,
         value: None,
+        start: 0,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-35.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-35.snap
@@ -6,5 +6,7 @@ description: "<<"
     Token {
         kind: LeftShift,
         value: None,
+        start: 0,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-36.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-36.snap
@@ -6,5 +6,7 @@ description: ">>"
     Token {
         kind: RightShift,
         value: None,
+        start: 0,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-37.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-37.snap
@@ -6,5 +6,7 @@ description: +
     Token {
         kind: Plus,
         value: None,
+        start: 0,
+        end: 1,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-38.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-38.snap
@@ -6,5 +6,7 @@ description: "-"
     Token {
         kind: Minus,
         value: None,
+        start: 0,
+        end: 1,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-39.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-39.snap
@@ -6,5 +6,7 @@ description: "*"
     Token {
         kind: Mul,
         value: None,
+        start: 0,
+        end: 1,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-4.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-4.snap
@@ -5,18 +5,24 @@ description: xX = 2
 [
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "xX",
         ),
+        start: 0,
+        end: 2,
     },
     Token {
         kind: Assign,
         value: None,
+        start: 3,
+        end: 4,
     },
     Token {
         kind: Integer,
         value: Number(
             "2",
         ),
+        start: 5,
+        end: 6,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-40.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-40.snap
@@ -6,5 +6,7 @@ description: "**"
     Token {
         kind: Pow,
         value: None,
+        start: 0,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-41.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-41.snap
@@ -6,5 +6,7 @@ description: /
     Token {
         kind: Div,
         value: None,
+        start: 0,
+        end: 1,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-42.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-42.snap
@@ -6,5 +6,7 @@ description: //
     Token {
         kind: IntDiv,
         value: None,
+        start: 0,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-43.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-43.snap
@@ -6,5 +6,7 @@ description: "%"
     Token {
         kind: Mod,
         value: None,
+        start: 0,
+        end: 1,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-44.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-44.snap
@@ -6,5 +6,7 @@ description: "@"
     Token {
         kind: MatrixMul,
         value: None,
+        start: 0,
+        end: 1,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-45.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-45.snap
@@ -6,5 +6,7 @@ description: "<<"
     Token {
         kind: LeftShift,
         value: None,
+        start: 0,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-46.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-46.snap
@@ -6,5 +6,7 @@ description: ">>"
     Token {
         kind: RightShift,
         value: None,
+        start: 0,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-47.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-47.snap
@@ -6,5 +6,7 @@ description: "&"
     Token {
         kind: BitAnd,
         value: None,
+        start: 0,
+        end: 1,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-48.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-48.snap
@@ -6,5 +6,7 @@ description: "|"
     Token {
         kind: BitOr,
         value: None,
+        start: 0,
+        end: 1,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-49.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-49.snap
@@ -6,5 +6,7 @@ description: ^
     Token {
         kind: BitXor,
         value: None,
+        start: 0,
+        end: 1,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-5.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-5.snap
@@ -6,13 +6,19 @@ description: if else elif
     Token {
         kind: If,
         value: None,
+        start: 0,
+        end: 2,
     },
     Token {
         kind: Else,
         value: None,
+        start: 3,
+        end: 7,
     },
     Token {
         kind: Elif,
         value: None,
+        start: 8,
+        end: 12,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-50.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-50.snap
@@ -6,5 +6,7 @@ description: "~"
     Token {
         kind: BitNot,
         value: None,
+        start: 0,
+        end: 1,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-51.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-51.snap
@@ -6,5 +6,7 @@ description: ":="
     Token {
         kind: Walrus,
         value: None,
+        start: 0,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-52.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-52.snap
@@ -6,5 +6,7 @@ description: "<"
     Token {
         kind: Less,
         value: None,
+        start: 0,
+        end: 1,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-53.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-53.snap
@@ -6,5 +6,7 @@ description: ">"
     Token {
         kind: Greater,
         value: None,
+        start: 0,
+        end: 1,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-54.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-54.snap
@@ -6,5 +6,7 @@ description: "<="
     Token {
         kind: LessEq,
         value: None,
+        start: 0,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-55.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-55.snap
@@ -6,5 +6,7 @@ description: ">="
     Token {
         kind: GreaterEq,
         value: None,
+        start: 0,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-56.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-56.snap
@@ -6,5 +6,7 @@ description: "=="
     Token {
         kind: Eq,
         value: None,
+        start: 0,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-57.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-57.snap
@@ -6,5 +6,7 @@ description: "!="
     Token {
         kind: NotEq,
         value: None,
+        start: 0,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-6.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-6.snap
@@ -6,9 +6,13 @@ description: ()
     Token {
         kind: LeftParen,
         value: None,
+        start: 0,
+        end: 1,
     },
     Token {
         kind: RightParen,
         value: None,
+        start: 1,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-7.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-7.snap
@@ -6,9 +6,13 @@ description: "[]"
     Token {
         kind: LeftBrace,
         value: None,
+        start: 0,
+        end: 1,
     },
     Token {
         kind: RightBrace,
         value: None,
+        start: 1,
+        end: 2,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-8.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-8.snap
@@ -6,13 +6,19 @@ description: "{}:"
     Token {
         kind: LeftBracket,
         value: None,
+        start: 0,
+        end: 1,
     },
     Token {
         kind: RightBracket,
         value: None,
+        start: 1,
+        end: 2,
     },
     Token {
         kind: Colon,
         value: None,
+        start: 2,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__test-lexer-9.snap
+++ b/src/snapshots/enderpy__lexer__tests__test-lexer-9.snap
@@ -6,5 +6,7 @@ description: "."
     Token {
         kind: Dot,
         value: None,
+        start: 0,
+        end: 1,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__unicode-string-literals-0.snap
+++ b/src/snapshots/enderpy__lexer__tests__unicode-string-literals-0.snap
@@ -5,8 +5,10 @@ description: "u\"hello\""
 [
     Token {
         kind: Unicode,
-        value: String(
+        value: Str(
             "u\"hello\"",
         ),
+        start: 0,
+        end: 8,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__unicode-string-literals-1.snap
+++ b/src/snapshots/enderpy__lexer__tests__unicode-string-literals-1.snap
@@ -5,8 +5,10 @@ description: "u\"world\""
 [
     Token {
         kind: Unicode,
-        value: String(
+        value: Str(
             "u\"world\"",
         ),
+        start: 0,
+        end: 8,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__unicode-string-literals-2.snap
+++ b/src/snapshots/enderpy__lexer__tests__unicode-string-literals-2.snap
@@ -5,8 +5,10 @@ description: "u\"\""
 [
     Token {
         kind: Unicode,
-        value: String(
+        value: Str(
             "u\"\"",
         ),
+        start: 0,
+        end: 3,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__unicode-string-literals-3.snap
+++ b/src/snapshots/enderpy__lexer__tests__unicode-string-literals-3.snap
@@ -5,18 +5,24 @@ description: "a = u\"hello\""
 [
     Token {
         kind: Identifier,
-        value: String(
+        value: Str(
             "a",
         ),
+        start: 0,
+        end: 1,
     },
     Token {
         kind: Assign,
         value: None,
+        start: 2,
+        end: 3,
     },
     Token {
         kind: Unicode,
-        value: String(
+        value: Str(
             "u\"hello\"",
         ),
+        start: 4,
+        end: 12,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__unicode-string-literals-4.snap
+++ b/src/snapshots/enderpy__lexer__tests__unicode-string-literals-4.snap
@@ -5,8 +5,10 @@ description: "u'hello'"
 [
     Token {
         kind: Unicode,
-        value: String(
+        value: Str(
             "u'hello'",
         ),
+        start: 0,
+        end: 8,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__unicode-string-literals-5.snap
+++ b/src/snapshots/enderpy__lexer__tests__unicode-string-literals-5.snap
@@ -5,8 +5,10 @@ description: "u\"\"\"hello\"\"\""
 [
     Token {
         kind: Unicode,
-        value: String(
+        value: Str(
             "u\"\"\"hello\"\"\"",
         ),
+        start: 0,
+        end: 12,
     },
 ]

--- a/src/snapshots/enderpy__lexer__tests__unicode-string-literals-6.snap
+++ b/src/snapshots/enderpy__lexer__tests__unicode-string-literals-6.snap
@@ -5,8 +5,10 @@ description: "u'''hello'''"
 [
     Token {
         kind: Unicode,
-        value: String(
+        value: Str(
             "u'''hello'''",
         ),
+        start: 0,
+        end: 12,
     },
 ]


### PR DESCRIPTION
This PR adds start and end offset to the Token struct.
Since TokenValue is a big struct we can later remove that part and leave it to the parser to extract the value based on this start and end.
Currently this has no new effect.									