### PR TITLE
Remove remaining from lexer

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -29,15 +29,15 @@ impl Lexer {
         if kind == Kind::WhiteSpace {
             return self.next_token();
         }
-        let kind_value = self.extract(start);
-        let value = self.read_value(kind, kind_value);
+        let raw_value = self.extract(start);
+        let value = self.read_value(kind, raw_value);
         let end = self.current;
-        return Token {
+        Token {
             kind,
             value,
             start,
             end,
-        };
+        }
     }
 
     fn next_kind(&mut self) -> Kind {
@@ -608,13 +608,13 @@ impl Lexer {
             match spaces_count.cmp(top) {
                 Ordering::Less => {
                     let kind = Kind::Dedent;
-                    return Some(kind);
+                    Some(kind)
                 }
                 Ordering::Equal => None,
                 Ordering::Greater => {
                     self.indent_stack.push(spaces_count);
                     let kind = Kind::Indent;
-                    return Some(kind);
+                    Some(kind)
                 }
             }
         } else {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -63,7 +63,7 @@ pub struct Parser {
 impl Parser {
     pub fn new(source: String) -> Self {
         let mut lexer = Lexer::new(&source);
-        let cur_token = lexer.read_next_token();
+        let cur_token = lexer.next_token();
         let prev_token_end = 0;
 
         Self {
@@ -127,7 +127,7 @@ impl Parser {
 
     /// Move to the next token
     fn advance(&mut self) {
-        let token = self.lexer.read_next_token();
+        let token = self.lexer.next_token();
         self.prev_token_end = self.cur_token.end;
         self.cur_token = token;
     }


### PR DESCRIPTION
I removed the `remaining` property from the lexer and added `start` and `current` to improve performance. It also made it a bit simpler or maybe not I'm not sure.