### PR TITLE
include the parent package of the execution source in search paths

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -87,9 +87,12 @@ fn check(path: &PathBuf) -> Result<()> {
         source,
         followed: false,
     };
-    let dir_of_path = path.parent().unwrap();
+    let root = path
+        .ancestors()
+        .find(|p| p.join("__init__.py").exists())
+        .ok_or_else(|| anyhow!("could not find root of project"))?;
     let python_executable = get_python_executable()?;
-    let settings = Settings { debug: true, root: dir_of_path.to_path_buf(), import_discovery: ImportDiscovery { python_executable } };
+    let settings = Settings { debug: true, root: PathBuf::from(root), import_discovery: ImportDiscovery { python_executable } };
     let mut build_manager = BuildManager::new(vec![initial_source], settings);
     build_manager.build();
 

--- a/ruff_python_import_resolver/src/implicit_imports.rs
+++ b/ruff_python_import_resolver/src/implicit_imports.rs
@@ -11,7 +11,7 @@ use crate::{native_module, py_typed};
 /// package, the symbols must be present as submodules. This map contains the submodules that are
 /// present in the namespace package, keyed by their module name.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub(crate) struct ImplicitImports(BTreeMap<String, ImplicitImport>);
+pub struct ImplicitImports(BTreeMap<String, ImplicitImport>);
 
 impl ImplicitImports {
     /// Find the "implicit" imports within the namespace package at the given path.
@@ -155,13 +155,13 @@ impl ImplicitImports {
     }
 
     /// Returns an iterator over the implicit imports in the namespace package.
-    pub(crate) fn iter(&self) -> impl Iterator<Item = (&String, &ImplicitImport)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &ImplicitImport)> {
         self.0.iter()
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ImplicitImport {
+pub struct ImplicitImport {
     /// Whether the implicit import is a stub file.
     pub(crate) is_stub_file: bool,
 
@@ -169,7 +169,7 @@ pub(crate) struct ImplicitImport {
     pub(crate) is_native_lib: bool,
 
     /// The path to the implicit import.
-    pub(crate) path: PathBuf,
+    pub path: PathBuf,
 
     /// The `py.typed` information for the implicit import, if any.
     pub(crate) py_typed: Option<py_typed::PyTypedInfo>,

--- a/ruff_python_import_resolver/src/import_result.rs
+++ b/ruff_python_import_resolver/src/import_result.rs
@@ -68,7 +68,7 @@ pub struct ImportResult {
 
     /// A map from file to resolved path, for all implicitly imported
     /// modules that are part of a namespace package.
-    pub(crate) implicit_imports: ImplicitImports,
+    pub implicit_imports: ImplicitImports,
 
     /// Any implicit imports whose symbols were explicitly imported (i.e., via
     /// a `from x import y` statement).

--- a/typechecker/src/ast_visitor_generic.rs
+++ b/typechecker/src/ast_visitor_generic.rs
@@ -1,3 +1,6 @@
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 use ast::{Expression, Statement};
 
 use parser::ast::{self, *};

--- a/typechecker/src/build.rs
+++ b/typechecker/src/build.rs
@@ -36,7 +36,7 @@ impl BuildManager {
         let mut modules = HashMap::new();
 
         for build_source in sources {
-            let mod_name = Self::get_mod_name(&build_source.path);
+            let mod_name = Self::get_module_name(&build_source.path);
             let file = Box::new(Self::parse_file(build_source));
             let symbol_table = SymbolTable::new(crate::symbol_table::SymbolTableType::Module, 0);
 
@@ -61,21 +61,11 @@ impl BuildManager {
         )
     }
 
-    pub fn get_mod_name(path: &PathBuf) -> String {
+    pub fn get_module_name(path: &PathBuf) -> String {
         path.to_str()
             .unwrap()
             .replace("/", ".")
             .replace("\\", ".")
-    }
-
-    pub fn get_module_name(source: &BuildSource) -> String {
-        source
-            .path
-            .file_stem()
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .to_string()
     }
 
     // Entry point to analyze the program
@@ -207,7 +197,7 @@ impl BuildManager {
             if resolved.is_import_found {
                 for resolved_path in resolved.resolved_paths.iter() {
                     let source = std::fs::read_to_string(resolved_path).unwrap();
-                    let module = Self::get_mod_name(resolved_path);
+                    let module = Self::get_module_name(resolved_path);
                     let build_source = BuildSource {
                         path: resolved_path.clone(),
                         module: module.clone(), 
@@ -220,7 +210,7 @@ impl BuildManager {
 
                 for  (name, implicit_import) in resolved.implicit_imports.iter() {
                     let source = std::fs::read_to_string(implicit_import.path.clone()).unwrap();
-                    let module = Self::get_mod_name(&implicit_import.path);
+                    let module = Self::get_module_name(&implicit_import.path);
                     let build_source = BuildSource {
                         path: implicit_import.path.clone(),
                         module: module.clone(),

--- a/typechecker/src/nodes.rs
+++ b/typechecker/src/nodes.rs
@@ -11,13 +11,13 @@ use parser::ast::{Import, ImportFrom, Module, Statement};
 
 use crate::ast_visitor::TraversalVisitor;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum ImportKinds {
     Import(Import),
     ImportFrom(ImportFrom),
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct EnderpyFile {
     pub module_name: String,
     // all the imports inside the file

--- a/typechecker/src/state.rs
+++ b/typechecker/src/state.rs
@@ -3,6 +3,7 @@ use crate::{
     symbol_table::SymbolTable,
 };
 
+#[derive(Debug, Clone)]
 pub struct State {
     pub file: Box<EnderpyFile>,
     symbol_table: SymbolTable,
@@ -18,7 +19,7 @@ impl State {
     /// entry point to fill up the symbol table from the global definitions
     pub fn populate_symbol_table(&mut self) {
         let mut sem_anal = SemanticAnalyzer::new(self.file.clone());
-        for stmt in &self.file.defs {
+        for stmt in &self.file.body {
             sem_anal.visit_stmt(stmt)
         }
         self.symbol_table = sem_anal.globals

--- a/typechecker/src/type_check/type_evaluator.rs
+++ b/typechecker/src/type_check/type_evaluator.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+#![allow(unused_variables)]
 use miette::{bail, miette, Result};
 use parser::ast;
 

--- a/typechecker/src/type_check/type_inference.rs
+++ b/typechecker/src/type_check/type_inference.rs
@@ -1,3 +1,6 @@
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
 use parser::ast::{self, BinaryOperator, Expression};
 
 use super::{builtins, types::Type};

--- a/typechecker/testdata/output/typechecker__build__tests__type_check_call.snap
+++ b/typechecker/testdata/output/typechecker__build__tests__type_check_call.snap
@@ -3,5 +3,5 @@ source: typechecker/src/build.rs
 description: "def function() -> int:\n    return 1\n\na = function()\nb = function() + \"1\"\nc = a + 1\nd = function() + 1\n\nfunction + 1\n"
 expression: result
 ---
-test line 5: Operator '+' not supported for types 'Int' and 'Str'
-test line 9: Operator '+' not supported for types 'function' and 'Int'
+test.py line 5: Operator '+' not supported for types 'Int' and 'Str'
+test.py line 9: Operator '+' not supported for types 'function' and 'Int'

--- a/typechecker/testdata/output/typechecker__build__tests__type_check_list.snap
+++ b/typechecker/testdata/output/typechecker__build__tests__type_check_list.snap
@@ -3,5 +3,5 @@ source: typechecker/src/build.rs
 description: "a: list[int] = [1, 2, 3]\n\nb = a[0] + 1\n\nc = a[0] + a[1]\n\n# invalid usage of types\nd = a[0] + \"str\"\n\n# valid reassignment\na = [1]\n# invalid reassignment\na = [1, 2, \"str\"]\n"
 expression: result
 ---
-test line 8: Operator '+' not supported for types 'Int' and 'Str'
-test line 13: Cannot assign type 'builtins.list[Unknown]' to variable of type 'builtins.list[Int]'
+test.py line 8: Operator '+' not supported for types 'Int' and 'Str'
+test.py line 13: Cannot assign type 'builtins.list[Unknown]' to variable of type 'builtins.list[Int]'

--- a/typechecker/testdata/output/typechecker__build__tests__type_check_undefined.snap
+++ b/typechecker/testdata/output/typechecker__build__tests__type_check_undefined.snap
@@ -3,6 +3,6 @@ source: typechecker/src/build.rs
 description: "a = b + 1\n\na = c()\n\n"
 expression: result
 ---
-test line 1: symbol b is not defined
-test line 1: symbol b is not defined
-test line 3: symbol c is not defined
+test.py line 1: symbol b is not defined
+test.py line 1: symbol b is not defined
+test.py line 3: symbol c is not defined

--- a/typechecker/testdata/output/typechecker__build__tests__type_check_var.snap
+++ b/typechecker/testdata/output/typechecker__build__tests__type_check_var.snap
@@ -3,4 +3,4 @@ source: typechecker/src/build.rs
 description: "a: int = 1\n\na + \"str\"\n\nb = a + 1\n\nc = b + b\n"
 expression: result
 ---
-test line 3: Operator '+' not supported for types 'Int' and 'Str'
+test.py line 3: Operator '+' not supported for types 'Int' and 'Str'


### PR DESCRIPTION
I think a good solution for now is to go upwards until there is no more __init__.py and include that final dir in the search path. This allows to use imports like `from pkg import a` where pkg is a user directory and the source script is located inside pkg.