### PR TITLE
Implement import from in symbol table

### DIFF
--- a/enderpy/src/main.rs
+++ b/enderpy/src/main.rs
@@ -28,7 +28,7 @@ fn symbols(path: &PathBuf) -> Result<()> {
     let dir_of_path = path.parent().unwrap();
     let python_executable = Some(get_python_executable()?);
     let settings = Settings {
-        debug: false,
+        debug: true,
         root: dir_of_path.to_path_buf(),
         import_discovery: ImportDiscovery { python_executable },
         follow_imports: enderpy_python_type_checker::settings::FollowImports::All,

--- a/parser/src/parser/ast.rs
+++ b/parser/src/parser/ast.rs
@@ -205,6 +205,16 @@ pub struct Alias {
     pub asname: Option<String>,
 }
 
+impl Alias {
+    pub fn name(&self) -> String {
+        if let Some(asname) = &self.asname {
+            asname.clone()
+        } else {
+            self.name.clone()
+        }
+    }
+}
+
 // https://docs.python.org/3/library/ast.html#ast.ImportFrom
 #[derive(Debug, Clone)]
 pub struct ImportFrom {

--- a/typechecker/Cargo.toml
+++ b/typechecker/Cargo.toml
@@ -14,4 +14,4 @@ env_logger = "0.10.0"
 tempfile = "3.8.0"
 
 [dev-dependencies]
-insta = { version = "1.28.0", features = ["yaml"] }
+insta = { version = "1.28.0", features = ["yaml", "filters"] }

--- a/typechecker/src/build.rs
+++ b/typechecker/src/build.rs
@@ -92,11 +92,10 @@ impl BuildManager {
         };
         let host = &ruff_python_resolver::host::StaticHost::new(vec![]);
         for state in self.modules.iter_mut() {
-            state.1.populate_symbol_table();
-
             state
                 .1
-                .resolve_file_imports(execution_environment, import_config, host)
+                .resolve_file_imports(execution_environment, import_config, host);
+            state.1.populate_symbol_table();
         }
     }
 

--- a/typechecker/src/build.rs
+++ b/typechecker/src/build.rs
@@ -399,6 +399,8 @@ mod tests {
                 let mut settings = insta::Settings::clone_current();
                 settings.set_snapshot_path("../testdata/output/");
                 settings.set_description(contents);
+                settings.add_filter(r"module_name: .*.typechecker.test_data.inputs.symbol_table..*.py",
+                    "module_name: [REDACTED]");
                 settings.bind(|| {
                     insta::assert_snapshot!(result);
                 });
@@ -441,6 +443,12 @@ mod tests {
             let mut settings = insta::Settings::clone_current();
             settings.set_snapshot_path("../testdata/output/");
             settings.set_description(fs::read_to_string(path).unwrap());
+            settings.add_filter(
+                r"/.*/typechecker/test_data/inputs/symbol_table",
+                "[REDACTED]",
+            );
+                settings.add_filter(r"module_name: .*.typechecker.test_data.inputs.symbol_table..*.py",
+                "module_name: [REDACTED]");
             settings.bind(|| {
                 insta::assert_snapshot!(result);
             });

--- a/typechecker/src/state.rs
+++ b/typechecker/src/state.rs
@@ -1,10 +1,16 @@
 use std::collections::HashMap;
 
 use crate::{
-    ast_visitor::TraversalVisitor, nodes::EnderpyFile, semantic_analyzer::SemanticAnalyzer,
-    symbol_table::SymbolTable, diagnostic::Diagnostic, ruff_python_import_resolver::{import_result::ImportResult, self, module_descriptor::ImportModuleDescriptor},
+    ast_visitor::TraversalVisitor,
+    diagnostic::Diagnostic,
+    nodes::EnderpyFile,
     ruff_python_import_resolver as ruff_python_resolver,
-    ruff_python_import_resolver::resolver
+    ruff_python_import_resolver::resolver,
+    ruff_python_import_resolver::{
+        self, import_result::ImportResult, module_descriptor::ImportModuleDescriptor,
+    },
+    semantic_analyzer::SemanticAnalyzer,
+    symbol_table::SymbolTable,
 };
 
 #[derive(Debug, Clone)]
@@ -43,18 +49,18 @@ impl State {
         execution_environment: &ruff_python_resolver::execution_environment::ExecutionEnvironment,
         import_config: &ruff_python_resolver::config::Config,
         host: &ruff_python_resolver::host::StaticHost,
-    ){
+    ) {
         for import in self.file.imports.iter() {
             let import_descriptions = match import {
                 crate::nodes::ImportKinds::Import(i) => i
                     .names
                     .iter()
-                    .map(
-                        |x| ruff_python_resolver::module_descriptor::ImportModuleDescriptor::from(x)                    )
+                    .map(|x| {
+                        ruff_python_resolver::module_descriptor::ImportModuleDescriptor::from(x)
+                    })
                     .collect::<Vec<ImportModuleDescriptor>>(),
                 crate::nodes::ImportKinds::ImportFrom(i) => {
-                    vec![
-                        ruff_python_resolver::module_descriptor::ImportModuleDescriptor::from(i)                    ]
+                    vec![ruff_python_resolver::module_descriptor::ImportModuleDescriptor::from(i)]
                 }
             };
 

--- a/typechecker/src/state.rs
+++ b/typechecker/src/state.rs
@@ -13,7 +13,7 @@ pub struct State {
     symbol_table: SymbolTable,
     pub diagnostics: Vec<Diagnostic>,
     // Map of import names to the result of the import
-    pub imports: HashMap<String, Box<ImportResult>>,
+    pub imports: HashMap<String, ImportResult>,
 }
 
 impl State {
@@ -66,7 +66,7 @@ impl State {
                     import_config,
                     host,
                 );
-                self.imports.insert(import_desc.name(), Box::new(resolved));
+                self.imports.insert(import_desc.name(), resolved);
             }
         }
     }

--- a/typechecker/src/symbol_table.rs
+++ b/typechecker/src/symbol_table.rs
@@ -1,7 +1,12 @@
 use enderpy_python_parser::ast::{self, Node};
 use std::{collections::HashMap, fmt::Display};
 
-use crate::ruff_python_import_resolver::import_result::ImportResult;
+use crate::{
+    nodes::ImportKinds,
+    ruff_python_import_resolver::{
+        import_result::ImportResult, module_descriptor::ImportModuleDescriptor,
+    },
+};
 
 #[derive(Debug, Clone)]
 pub struct SymbolTable {
@@ -118,7 +123,13 @@ pub struct Paramter {
 #[derive(Debug, Clone)]
 pub struct Alias {
     pub declaration_path: DeclarationPath,
-    pub alias_node: ast::Alias,
+    /// The import node that this alias is for. Only one of import_node or import_from_node will be set
+    pub import_from_node: Option<ast::ImportFrom>,
+    pub import_node: Option<ast::Import>,
+    /// Name of the imported symbol in case of ImportFrom
+    /// e.g. From bar import baz -> baz is the symbol name
+    pub symbol_name: Option<String>,
+    /// The result of the import
     pub import_result: ImportResult,
 }
 

--- a/typechecker/src/symbol_table.rs
+++ b/typechecker/src/symbol_table.rs
@@ -119,7 +119,7 @@ pub struct Paramter {
 pub struct Alias {
     pub declaration_path: DeclarationPath,
     pub alias_node: ast::Alias,
-    pub import_result: Box<ImportResult>,
+    pub import_result: ImportResult,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -273,11 +273,11 @@ impl std::fmt::Display for SymbolTableScope {
 impl std::fmt::Display for Declaration {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Declaration::Variable(v) => write!(f, "{:?}", v),
-            Declaration::Function(fun) => write!(f, "{:?}", fun),
-            Declaration::Class(c) => write!(f, "{:?}", c),
-            Declaration::Parameter(p) => write!(f, "{:?}", p),
-            Declaration::Alias(a) => write!(f, "{:?}", a),
+            Declaration::Variable(v) => write!(f, "{:#?}", v),
+            Declaration::Function(fun) => write!(f, "{:#?}", fun),
+            Declaration::Class(c) => write!(f, "{:#?}", c),
+            Declaration::Parameter(p) => write!(f, "{:#?}", p),
+            Declaration::Alias(a) => write!(f, "{:#?}", a),
         }
     }
 }

--- a/typechecker/test_data/inputs/symbol_table/imports.py
+++ b/typechecker/test_data/inputs/symbol_table/imports.py
@@ -1,1 +1,4 @@
 import variables
+import import_test
+
+from variables import a

--- a/typechecker/test_data/inputs/symbol_table/imports.py
+++ b/typechecker/test_data/inputs/symbol_table/imports.py
@@ -2,7 +2,10 @@ import variables
 import import_test
 
 from variables import a
+from variables import *
 
 import os.path
+
+from os import *
 
 from os.path import join

--- a/typechecker/test_data/inputs/symbol_table/imports.py
+++ b/typechecker/test_data/inputs/symbol_table/imports.py
@@ -2,3 +2,7 @@ import variables
 import import_test
 
 from variables import a
+
+import os.path
+
+from os.path import join

--- a/typechecker/testdata/output/enderpy_python_type_checker__build__tests__symbol_table@class_definition.py.snap
+++ b/typechecker/testdata/output/enderpy_python_type_checker__build__tests__symbol_table@class_definition.py.snap
@@ -11,7 +11,7 @@ c
 - Declarations:
 --:   Class {
     declaration_path: DeclarationPath {
-        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.class_definition.py",
+        module_name: [REDACTED]",
         node: Node {
             start: 0,
             end: 47,
@@ -28,7 +28,7 @@ a
 - Declarations:
 --:   Variable {
     declaration_path: DeclarationPath {
-        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.class_definition.py",
+        module_name: [REDACTED]",
         node: Node {
             start: 41,
             end: 46,
@@ -53,7 +53,7 @@ self
 - Declarations:
 --:   Paramter {
     declaration_path: DeclarationPath {
-        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.class_definition.py",
+        module_name: [REDACTED]",
         node: Node {
             start: 26,
             end: 30,
@@ -76,7 +76,7 @@ __init__
 - Declarations:
 --:   Function {
     declaration_path: DeclarationPath {
-        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.class_definition.py",
+        module_name: [REDACTED]",
         node: Node {
             start: 13,
             end: 47,

--- a/typechecker/testdata/output/enderpy_python_type_checker__build__tests__symbol_table@class_definition.py.snap
+++ b/typechecker/testdata/output/enderpy_python_type_checker__build__tests__symbol_table@class_definition.py.snap
@@ -9,21 +9,147 @@ global scope:
 Symbols:
 c
 - Declarations:
---:   Class { declaration_path: DeclarationPath { module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.class_definition.py", node: Node { start: 0, end: 47 } }, methods: ["__init__"] }
+--:   Class {
+    declaration_path: DeclarationPath {
+        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.class_definition.py",
+        node: Node {
+            start: 0,
+            end: 47,
+        },
+    },
+    methods: [
+        "__init__",
+    ],
+}
 
 all scopes:
 Symbols:
 a
 - Declarations:
---:   Variable { declaration_path: DeclarationPath { module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.class_definition.py", node: Node { start: 41, end: 46 } }, scope: Global, type_annotation: None, inferred_type_source: Some(Constant(Constant { node: Node { start: 45, end: 46 }, value: 1 })), is_constant: false }
+--:   Variable {
+    declaration_path: DeclarationPath {
+        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.class_definition.py",
+        node: Node {
+            start: 41,
+            end: 46,
+        },
+    },
+    scope: Global,
+    type_annotation: None,
+    inferred_type_source: Some(
+        Constant(
+            Constant {
+                node: Node {
+                    start: 45,
+                    end: 46,
+                },
+                value: 1,
+            },
+        ),
+    ),
+    is_constant: false,
+}
 self
 - Declarations:
---:   Paramter { declaration_path: DeclarationPath { module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.class_definition.py", node: Node { start: 26, end: 30 } }, parameter_node: Arg { node: Node { start: 26, end: 30 }, arg: "self", annotation: None }, type_annotation: None, default_value: None }
+--:   Paramter {
+    declaration_path: DeclarationPath {
+        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.class_definition.py",
+        node: Node {
+            start: 26,
+            end: 30,
+        },
+    },
+    parameter_node: Arg {
+        node: Node {
+            start: 26,
+            end: 30,
+        },
+        arg: "self",
+        annotation: None,
+    },
+    type_annotation: None,
+    default_value: None,
+}
 
 Symbols:
 __init__
 - Declarations:
---:   Function { declaration_path: DeclarationPath { module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.class_definition.py", node: Node { start: 13, end: 47 } }, function_node: FunctionDef { node: Node { start: 13, end: 47 }, name: "__init__", args: Arguments { node: Node { start: 26, end: 30 }, posonlyargs: [], args: [Arg { node: Node { start: 26, end: 30 }, arg: "self", annotation: None }], vararg: None, kwonlyargs: [], kw_defaults: [], kwarg: None, defaults: [] }, body: [AssignStatement(Assign { node: Node { start: 41, end: 46 }, targets: [Name(Name { node: Node { start: 41, end: 42 }, id: "a" })], value: Constant(Constant { node: Node { start: 45, end: 46 }, value: 1 }) })], decorator_list: [], returns: None, type_comment: None }, is_method: true, is_generator: false, return_statements: [], yeild_statements: [], raise_statements: [] }
+--:   Function {
+    declaration_path: DeclarationPath {
+        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.class_definition.py",
+        node: Node {
+            start: 13,
+            end: 47,
+        },
+    },
+    function_node: FunctionDef {
+        node: Node {
+            start: 13,
+            end: 47,
+        },
+        name: "__init__",
+        args: Arguments {
+            node: Node {
+                start: 26,
+                end: 30,
+            },
+            posonlyargs: [],
+            args: [
+                Arg {
+                    node: Node {
+                        start: 26,
+                        end: 30,
+                    },
+                    arg: "self",
+                    annotation: None,
+                },
+            ],
+            vararg: None,
+            kwonlyargs: [],
+            kw_defaults: [],
+            kwarg: None,
+            defaults: [],
+        },
+        body: [
+            AssignStatement(
+                Assign {
+                    node: Node {
+                        start: 41,
+                        end: 46,
+                    },
+                    targets: [
+                        Name(
+                            Name {
+                                node: Node {
+                                    start: 41,
+                                    end: 42,
+                                },
+                                id: "a",
+                            },
+                        ),
+                    ],
+                    value: Constant(
+                        Constant {
+                            node: Node {
+                                start: 45,
+                                end: 46,
+                            },
+                            value: 1,
+                        },
+                    ),
+                },
+            ),
+        ],
+        decorator_list: [],
+        returns: None,
+        type_comment: None,
+    },
+    is_method: true,
+    is_generator: false,
+    return_statements: [],
+    yeild_statements: [],
+    raise_statements: [],
+}
 
 -------------------
 

--- a/typechecker/testdata/output/enderpy_python_type_checker__build__tests__symbol_table@function_definition.py.snap
+++ b/typechecker/testdata/output/enderpy_python_type_checker__build__tests__symbol_table@function_definition.py.snap
@@ -9,22 +9,195 @@ global scope:
 Symbols:
 func
 - Declarations:
---:   Function { declaration_path: DeclarationPath { module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.function_definition.py", node: Node { start: 0, end: 37 } }, function_node: FunctionDef { node: Node { start: 0, end: 37 }, name: "func", args: Arguments { node: Node { start: 9, end: 29 }, posonlyargs: [Arg { node: Node { start: 9, end: 10 }, arg: "a", annotation: None }, Arg { node: Node { start: 12, end: 13 }, arg: "b", annotation: None }], args: [Arg { node: Node { start: 19, end: 24 }, arg: "c", annotation: None }], vararg: None, kwonlyargs: [], kw_defaults: [], kwarg: Some(Arg { node: Node { start: 28, end: 29 }, arg: "e", annotation: None }), defaults: [Constant(Constant { node: Node { start: 23, end: 24 }, value: 2 })] }, body: [Pass(Pass { node: Node { start: 32, end: 36 } })], decorator_list: [], returns: None, type_comment: None }, is_method: false, is_generator: false, return_statements: [], yeild_statements: [], raise_statements: [] }
+--:   Function {
+    declaration_path: DeclarationPath {
+        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.function_definition.py",
+        node: Node {
+            start: 0,
+            end: 37,
+        },
+    },
+    function_node: FunctionDef {
+        node: Node {
+            start: 0,
+            end: 37,
+        },
+        name: "func",
+        args: Arguments {
+            node: Node {
+                start: 9,
+                end: 29,
+            },
+            posonlyargs: [
+                Arg {
+                    node: Node {
+                        start: 9,
+                        end: 10,
+                    },
+                    arg: "a",
+                    annotation: None,
+                },
+                Arg {
+                    node: Node {
+                        start: 12,
+                        end: 13,
+                    },
+                    arg: "b",
+                    annotation: None,
+                },
+            ],
+            args: [
+                Arg {
+                    node: Node {
+                        start: 19,
+                        end: 24,
+                    },
+                    arg: "c",
+                    annotation: None,
+                },
+            ],
+            vararg: None,
+            kwonlyargs: [],
+            kw_defaults: [],
+            kwarg: Some(
+                Arg {
+                    node: Node {
+                        start: 28,
+                        end: 29,
+                    },
+                    arg: "e",
+                    annotation: None,
+                },
+            ),
+            defaults: [
+                Constant(
+                    Constant {
+                        node: Node {
+                            start: 23,
+                            end: 24,
+                        },
+                        value: 2,
+                    },
+                ),
+            ],
+        },
+        body: [
+            Pass(
+                Pass {
+                    node: Node {
+                        start: 32,
+                        end: 36,
+                    },
+                },
+            ),
+        ],
+        decorator_list: [],
+        returns: None,
+        type_comment: None,
+    },
+    is_method: false,
+    is_generator: false,
+    return_statements: [],
+    yeild_statements: [],
+    raise_statements: [],
+}
 
 all scopes:
 Symbols:
 a
 - Declarations:
---:   Paramter { declaration_path: DeclarationPath { module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.function_definition.py", node: Node { start: 9, end: 10 } }, parameter_node: Arg { node: Node { start: 9, end: 10 }, arg: "a", annotation: None }, type_annotation: None, default_value: None }
+--:   Paramter {
+    declaration_path: DeclarationPath {
+        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.function_definition.py",
+        node: Node {
+            start: 9,
+            end: 10,
+        },
+    },
+    parameter_node: Arg {
+        node: Node {
+            start: 9,
+            end: 10,
+        },
+        arg: "a",
+        annotation: None,
+    },
+    type_annotation: None,
+    default_value: None,
+}
 b
 - Declarations:
---:   Paramter { declaration_path: DeclarationPath { module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.function_definition.py", node: Node { start: 12, end: 13 } }, parameter_node: Arg { node: Node { start: 12, end: 13 }, arg: "b", annotation: None }, type_annotation: None, default_value: None }
+--:   Paramter {
+    declaration_path: DeclarationPath {
+        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.function_definition.py",
+        node: Node {
+            start: 12,
+            end: 13,
+        },
+    },
+    parameter_node: Arg {
+        node: Node {
+            start: 12,
+            end: 13,
+        },
+        arg: "b",
+        annotation: None,
+    },
+    type_annotation: None,
+    default_value: None,
+}
 c
 - Declarations:
---:   Paramter { declaration_path: DeclarationPath { module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.function_definition.py", node: Node { start: 19, end: 24 } }, parameter_node: Arg { node: Node { start: 19, end: 24 }, arg: "c", annotation: None }, type_annotation: None, default_value: Some(Constant(Constant { node: Node { start: 23, end: 24 }, value: 2 })) }
+--:   Paramter {
+    declaration_path: DeclarationPath {
+        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.function_definition.py",
+        node: Node {
+            start: 19,
+            end: 24,
+        },
+    },
+    parameter_node: Arg {
+        node: Node {
+            start: 19,
+            end: 24,
+        },
+        arg: "c",
+        annotation: None,
+    },
+    type_annotation: None,
+    default_value: Some(
+        Constant(
+            Constant {
+                node: Node {
+                    start: 23,
+                    end: 24,
+                },
+                value: 2,
+            },
+        ),
+    ),
+}
 e
 - Declarations:
---:   Paramter { declaration_path: DeclarationPath { module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.function_definition.py", node: Node { start: 28, end: 29 } }, parameter_node: Arg { node: Node { start: 28, end: 29 }, arg: "e", annotation: None }, type_annotation: None, default_value: None }
+--:   Paramter {
+    declaration_path: DeclarationPath {
+        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.function_definition.py",
+        node: Node {
+            start: 28,
+            end: 29,
+        },
+    },
+    parameter_node: Arg {
+        node: Node {
+            start: 28,
+            end: 29,
+        },
+        arg: "e",
+        annotation: None,
+    },
+    type_annotation: None,
+    default_value: None,
+}
 
 -------------------
 

--- a/typechecker/testdata/output/enderpy_python_type_checker__build__tests__symbol_table@function_definition.py.snap
+++ b/typechecker/testdata/output/enderpy_python_type_checker__build__tests__symbol_table@function_definition.py.snap
@@ -11,7 +11,7 @@ func
 - Declarations:
 --:   Function {
     declaration_path: DeclarationPath {
-        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.function_definition.py",
+        module_name: [REDACTED]",
         node: Node {
             start: 0,
             end: 37,
@@ -108,7 +108,7 @@ a
 - Declarations:
 --:   Paramter {
     declaration_path: DeclarationPath {
-        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.function_definition.py",
+        module_name: [REDACTED]",
         node: Node {
             start: 9,
             end: 10,
@@ -129,7 +129,7 @@ b
 - Declarations:
 --:   Paramter {
     declaration_path: DeclarationPath {
-        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.function_definition.py",
+        module_name: [REDACTED]",
         node: Node {
             start: 12,
             end: 13,
@@ -150,7 +150,7 @@ c
 - Declarations:
 --:   Paramter {
     declaration_path: DeclarationPath {
-        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.function_definition.py",
+        module_name: [REDACTED]",
         node: Node {
             start: 19,
             end: 24,
@@ -181,7 +181,7 @@ e
 - Declarations:
 --:   Paramter {
     declaration_path: DeclarationPath {
-        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.function_definition.py",
+        module_name: [REDACTED]",
         node: Node {
             start: 28,
             end: 29,

--- a/typechecker/testdata/output/enderpy_python_type_checker__build__tests__symbol_table@imports.py.snap
+++ b/typechecker/testdata/output/enderpy_python_type_checker__build__tests__symbol_table@imports.py.snap
@@ -1,15 +1,158 @@
 ---
 source: typechecker/src/build.rs
-description: "import variables\n"
+description: "import variables\nimport import_test\n\nfrom variables import a\n"
 expression: result
 input_file: typechecker/test_data/inputs/symbol_table/imports.py
 ---
 -------------------
 global scope:
 Symbols:
+a
+- Declarations:
+--:   Alias {
+    declaration_path: DeclarationPath {
+        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.imports.py",
+        node: Node {
+            start: 59,
+            end: 60,
+        },
+    },
+    alias_node: Alias {
+        node: Node {
+            start: 59,
+            end: 60,
+        },
+        name: "a",
+        asname: None,
+    },
+    import_result: ImportResult {
+        is_relative: false,
+        is_import_found: true,
+        is_partly_resolved: false,
+        is_namespace_package: false,
+        is_init_file_present: false,
+        is_stub_package: false,
+        import_type: Local,
+        resolved_paths: [
+            "/Users/glyphack/Programming/enderpy/typechecker/test_data/inputs/symbol_table/variables.py",
+        ],
+        search_path: Some(
+            "/Users/glyphack/Programming/enderpy/typechecker/test_data/inputs/symbol_table",
+        ),
+        is_stub_file: false,
+        is_native_lib: false,
+        is_stdlib_typeshed_file: false,
+        is_third_party_typeshed_file: false,
+        is_local_typings_file: false,
+        implicit_imports: ImplicitImports(
+            {},
+        ),
+        filtered_implicit_imports: ImplicitImports(
+            {},
+        ),
+        non_stub_import_result: None,
+        py_typed_info: None,
+        package_directory: None,
+    },
+}
+import_test
+- Declarations:
+--:   Alias {
+    declaration_path: DeclarationPath {
+        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.imports.py",
+        node: Node {
+            start: 24,
+            end: 35,
+        },
+    },
+    alias_node: Alias {
+        node: Node {
+            start: 24,
+            end: 35,
+        },
+        name: "import_test",
+        asname: None,
+    },
+    import_result: ImportResult {
+        is_relative: false,
+        is_import_found: true,
+        is_partly_resolved: false,
+        is_namespace_package: false,
+        is_init_file_present: true,
+        is_stub_package: false,
+        import_type: Local,
+        resolved_paths: [
+            "/Users/glyphack/Programming/enderpy/typechecker/test_data/inputs/symbol_table/import_test/__init__.py",
+        ],
+        search_path: Some(
+            "/Users/glyphack/Programming/enderpy/typechecker/test_data/inputs/symbol_table",
+        ),
+        is_stub_file: false,
+        is_native_lib: false,
+        is_stdlib_typeshed_file: false,
+        is_third_party_typeshed_file: false,
+        is_local_typings_file: false,
+        implicit_imports: ImplicitImports(
+            {},
+        ),
+        filtered_implicit_imports: ImplicitImports(
+            {},
+        ),
+        non_stub_import_result: None,
+        py_typed_info: None,
+        package_directory: Some(
+            "/Users/glyphack/Programming/enderpy/typechecker/test_data/inputs/symbol_table/import_test",
+        ),
+    },
+}
 variables
 - Declarations:
---:   Alias { declaration_path: DeclarationPath { module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.imports.py", node: Node { start: 7, end: 16 } }, alias_node: Alias { node: Node { start: 7, end: 16 }, name: "variables", asname: None }, import_result: ImportResult { is_relative: false, is_import_found: false, is_partly_resolved: false, is_namespace_package: false, is_init_file_present: false, is_stub_package: false, import_type: Local, resolved_paths: [], search_path: None, is_stub_file: false, is_native_lib: false, is_stdlib_typeshed_file: false, is_third_party_typeshed_file: false, is_local_typings_file: false, implicit_imports: ImplicitImports({}), filtered_implicit_imports: ImplicitImports({}), non_stub_import_result: None, py_typed_info: None, package_directory: None } }
+--:   Alias {
+    declaration_path: DeclarationPath {
+        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.imports.py",
+        node: Node {
+            start: 7,
+            end: 16,
+        },
+    },
+    alias_node: Alias {
+        node: Node {
+            start: 7,
+            end: 16,
+        },
+        name: "variables",
+        asname: None,
+    },
+    import_result: ImportResult {
+        is_relative: false,
+        is_import_found: true,
+        is_partly_resolved: false,
+        is_namespace_package: false,
+        is_init_file_present: false,
+        is_stub_package: false,
+        import_type: Local,
+        resolved_paths: [
+            "/Users/glyphack/Programming/enderpy/typechecker/test_data/inputs/symbol_table/variables.py",
+        ],
+        search_path: Some(
+            "/Users/glyphack/Programming/enderpy/typechecker/test_data/inputs/symbol_table",
+        ),
+        is_stub_file: false,
+        is_native_lib: false,
+        is_stdlib_typeshed_file: false,
+        is_third_party_typeshed_file: false,
+        is_local_typings_file: false,
+        implicit_imports: ImplicitImports(
+            {},
+        ),
+        filtered_implicit_imports: ImplicitImports(
+            {},
+        ),
+        non_stub_import_result: None,
+        py_typed_info: None,
+        package_directory: None,
+    },
+}
 
 all scopes:
 -------------------

--- a/typechecker/testdata/output/enderpy_python_type_checker__build__tests__symbol_table@imports.py.snap
+++ b/typechecker/testdata/output/enderpy_python_type_checker__build__tests__symbol_table@imports.py.snap
@@ -1,12 +1,134 @@
 ---
 source: typechecker/src/build.rs
-description: "import variables\nimport import_test\n\nfrom variables import a\n\nimport os.path\n\nfrom os.path import join\n"
+description: "import variables\nimport import_test\n\nfrom variables import a\nfrom variables import *\n\nimport os.path\n\nfrom os import *\n\nfrom os.path import join\n"
 expression: result
 input_file: typechecker/test_data/inputs/symbol_table/imports.py
 ---
 -------------------
 global scope:
 Symbols:
+*
+- Declarations:
+--:   Alias {
+    declaration_path: DeclarationPath {
+        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.imports.py",
+        node: Node {
+            start: 83,
+            end: 82,
+        },
+    },
+    import_from_node: Some(
+        ImportFrom {
+            node: Node {
+                start: 61,
+                end: 84,
+            },
+            module: "variables",
+            names: [
+                Alias {
+                    node: Node {
+                        start: 83,
+                        end: 82,
+                    },
+                    name: "*",
+                    asname: None,
+                },
+            ],
+            level: 0,
+        },
+    ),
+    import_node: None,
+    symbol_name: Some(
+        "*",
+    ),
+    import_result: ImportResult {
+        is_relative: false,
+        is_import_found: true,
+        is_partly_resolved: false,
+        is_namespace_package: false,
+        is_init_file_present: false,
+        is_stub_package: false,
+        import_type: Local,
+        resolved_paths: [
+            "/Users/glyphack/Programming/enderpy/typechecker/test_data/inputs/symbol_table/variables.py",
+        ],
+        search_path: Some(
+            "/Users/glyphack/Programming/enderpy/typechecker/test_data/inputs/symbol_table",
+        ),
+        is_stub_file: false,
+        is_native_lib: false,
+        is_stdlib_typeshed_file: false,
+        is_third_party_typeshed_file: false,
+        is_local_typings_file: false,
+        implicit_imports: ImplicitImports(
+            {},
+        ),
+        filtered_implicit_imports: ImplicitImports(
+            {},
+        ),
+        non_stub_import_result: None,
+        py_typed_info: None,
+        package_directory: None,
+    },
+}
+--:   Alias {
+    declaration_path: DeclarationPath {
+        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.imports.py",
+        node: Node {
+            start: 117,
+            end: 116,
+        },
+    },
+    import_from_node: Some(
+        ImportFrom {
+            node: Node {
+                start: 102,
+                end: 118,
+            },
+            module: "os",
+            names: [
+                Alias {
+                    node: Node {
+                        start: 117,
+                        end: 116,
+                    },
+                    name: "*",
+                    asname: None,
+                },
+            ],
+            level: 0,
+        },
+    ),
+    import_node: None,
+    symbol_name: Some(
+        "*",
+    ),
+    import_result: ImportResult {
+        is_relative: false,
+        is_import_found: false,
+        is_partly_resolved: false,
+        is_namespace_package: false,
+        is_init_file_present: false,
+        is_stub_package: false,
+        import_type: Local,
+        resolved_paths: [],
+        search_path: None,
+        is_stub_file: false,
+        is_native_lib: false,
+        is_stdlib_typeshed_file: false,
+        is_third_party_typeshed_file: false,
+        is_local_typings_file: false,
+        implicit_imports: ImplicitImports(
+            {},
+        ),
+        filtered_implicit_imports: ImplicitImports(
+            {},
+        ),
+        non_stub_import_result: None,
+        py_typed_info: None,
+        package_directory: None,
+    },
+}
 a
 - Declarations:
 --:   Alias {
@@ -139,22 +261,22 @@ join
     declaration_path: DeclarationPath {
         module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.imports.py",
         node: Node {
-            start: 98,
-            end: 102,
+            start: 140,
+            end: 144,
         },
     },
     import_from_node: Some(
         ImportFrom {
             node: Node {
-                start: 78,
-                end: 102,
+                start: 120,
+                end: 144,
             },
             module: "os.path",
             names: [
                 Alias {
                     node: Node {
-                        start: 98,
-                        end: 102,
+                        start: 140,
+                        end: 144,
                     },
                     name: "join",
                     asname: None,
@@ -199,22 +321,22 @@ os.path
     declaration_path: DeclarationPath {
         module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.imports.py",
         node: Node {
-            start: 69,
-            end: 76,
+            start: 93,
+            end: 100,
         },
     },
     import_from_node: None,
     import_node: Some(
         Import {
             node: Node {
-                start: 62,
-                end: 76,
+                start: 86,
+                end: 100,
             },
             names: [
                 Alias {
                     node: Node {
-                        start: 69,
-                        end: 76,
+                        start: 93,
+                        end: 100,
                     },
                     name: "os.path",
                     asname: None,

--- a/typechecker/testdata/output/enderpy_python_type_checker__build__tests__symbol_table@imports.py.snap
+++ b/typechecker/testdata/output/enderpy_python_type_checker__build__tests__symbol_table@imports.py.snap
@@ -11,7 +11,7 @@ Symbols:
 - Declarations:
 --:   Alias {
     declaration_path: DeclarationPath {
-        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.imports.py",
+        module_name: [REDACTED]",
         node: Node {
             start: 83,
             end: 82,
@@ -50,10 +50,10 @@ Symbols:
         is_stub_package: false,
         import_type: Local,
         resolved_paths: [
-            "/Users/glyphack/Programming/enderpy/typechecker/test_data/inputs/symbol_table/variables.py",
+            "[REDACTED]/variables.py",
         ],
         search_path: Some(
-            "/Users/glyphack/Programming/enderpy/typechecker/test_data/inputs/symbol_table",
+            "[REDACTED]",
         ),
         is_stub_file: false,
         is_native_lib: false,
@@ -73,7 +73,7 @@ Symbols:
 }
 --:   Alias {
     declaration_path: DeclarationPath {
-        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.imports.py",
+        module_name: [REDACTED]",
         node: Node {
             start: 117,
             end: 116,
@@ -133,7 +133,7 @@ a
 - Declarations:
 --:   Alias {
     declaration_path: DeclarationPath {
-        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.imports.py",
+        module_name: [REDACTED]",
         node: Node {
             start: 59,
             end: 60,
@@ -172,10 +172,10 @@ a
         is_stub_package: false,
         import_type: Local,
         resolved_paths: [
-            "/Users/glyphack/Programming/enderpy/typechecker/test_data/inputs/symbol_table/variables.py",
+            "[REDACTED]/variables.py",
         ],
         search_path: Some(
-            "/Users/glyphack/Programming/enderpy/typechecker/test_data/inputs/symbol_table",
+            "[REDACTED]",
         ),
         is_stub_file: false,
         is_native_lib: false,
@@ -197,7 +197,7 @@ import_test
 - Declarations:
 --:   Alias {
     declaration_path: DeclarationPath {
-        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.imports.py",
+        module_name: [REDACTED]",
         node: Node {
             start: 24,
             end: 35,
@@ -232,10 +232,10 @@ import_test
         is_stub_package: false,
         import_type: Local,
         resolved_paths: [
-            "/Users/glyphack/Programming/enderpy/typechecker/test_data/inputs/symbol_table/import_test/__init__.py",
+            "[REDACTED]/import_test/__init__.py",
         ],
         search_path: Some(
-            "/Users/glyphack/Programming/enderpy/typechecker/test_data/inputs/symbol_table",
+            "[REDACTED]",
         ),
         is_stub_file: false,
         is_native_lib: false,
@@ -251,7 +251,7 @@ import_test
         non_stub_import_result: None,
         py_typed_info: None,
         package_directory: Some(
-            "/Users/glyphack/Programming/enderpy/typechecker/test_data/inputs/symbol_table/import_test",
+            "[REDACTED]/import_test",
         ),
     },
 }
@@ -259,7 +259,7 @@ join
 - Declarations:
 --:   Alias {
     declaration_path: DeclarationPath {
-        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.imports.py",
+        module_name: [REDACTED]",
         node: Node {
             start: 140,
             end: 144,
@@ -319,7 +319,7 @@ os.path
 - Declarations:
 --:   Alias {
     declaration_path: DeclarationPath {
-        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.imports.py",
+        module_name: [REDACTED]",
         node: Node {
             start: 93,
             end: 100,
@@ -375,7 +375,7 @@ variables
 - Declarations:
 --:   Alias {
     declaration_path: DeclarationPath {
-        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.imports.py",
+        module_name: [REDACTED]",
         node: Node {
             start: 7,
             end: 16,
@@ -410,10 +410,10 @@ variables
         is_stub_package: false,
         import_type: Local,
         resolved_paths: [
-            "/Users/glyphack/Programming/enderpy/typechecker/test_data/inputs/symbol_table/variables.py",
+            "[REDACTED]/variables.py",
         ],
         search_path: Some(
-            "/Users/glyphack/Programming/enderpy/typechecker/test_data/inputs/symbol_table",
+            "[REDACTED]",
         ),
         is_stub_file: false,
         is_native_lib: false,

--- a/typechecker/testdata/output/enderpy_python_type_checker__build__tests__symbol_table@imports.py.snap
+++ b/typechecker/testdata/output/enderpy_python_type_checker__build__tests__symbol_table@imports.py.snap
@@ -1,6 +1,6 @@
 ---
 source: typechecker/src/build.rs
-description: "import variables\nimport import_test\n\nfrom variables import a\n"
+description: "import variables\nimport import_test\n\nfrom variables import a\n\nimport os.path\n\nfrom os.path import join\n"
 expression: result
 input_file: typechecker/test_data/inputs/symbol_table/imports.py
 ---
@@ -17,14 +17,30 @@ a
             end: 60,
         },
     },
-    alias_node: Alias {
-        node: Node {
-            start: 59,
-            end: 60,
+    import_from_node: Some(
+        ImportFrom {
+            node: Node {
+                start: 37,
+                end: 60,
+            },
+            module: "variables",
+            names: [
+                Alias {
+                    node: Node {
+                        start: 59,
+                        end: 60,
+                    },
+                    name: "a",
+                    asname: None,
+                },
+            ],
+            level: 0,
         },
-        name: "a",
-        asname: None,
-    },
+    ),
+    import_node: None,
+    symbol_name: Some(
+        "a",
+    ),
     import_result: ImportResult {
         is_relative: false,
         is_import_found: true,
@@ -65,14 +81,26 @@ import_test
             end: 35,
         },
     },
-    alias_node: Alias {
-        node: Node {
-            start: 24,
-            end: 35,
+    import_from_node: None,
+    import_node: Some(
+        Import {
+            node: Node {
+                start: 17,
+                end: 35,
+            },
+            names: [
+                Alias {
+                    node: Node {
+                        start: 24,
+                        end: 35,
+                    },
+                    name: "import_test",
+                    asname: None,
+                },
+            ],
         },
-        name: "import_test",
-        asname: None,
-    },
+    ),
+    symbol_name: None,
     import_result: ImportResult {
         is_relative: false,
         is_import_found: true,
@@ -105,6 +133,122 @@ import_test
         ),
     },
 }
+join
+- Declarations:
+--:   Alias {
+    declaration_path: DeclarationPath {
+        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.imports.py",
+        node: Node {
+            start: 98,
+            end: 102,
+        },
+    },
+    import_from_node: Some(
+        ImportFrom {
+            node: Node {
+                start: 78,
+                end: 102,
+            },
+            module: "os.path",
+            names: [
+                Alias {
+                    node: Node {
+                        start: 98,
+                        end: 102,
+                    },
+                    name: "join",
+                    asname: None,
+                },
+            ],
+            level: 0,
+        },
+    ),
+    import_node: None,
+    symbol_name: Some(
+        "join",
+    ),
+    import_result: ImportResult {
+        is_relative: false,
+        is_import_found: false,
+        is_partly_resolved: false,
+        is_namespace_package: false,
+        is_init_file_present: false,
+        is_stub_package: false,
+        import_type: Local,
+        resolved_paths: [],
+        search_path: None,
+        is_stub_file: false,
+        is_native_lib: false,
+        is_stdlib_typeshed_file: false,
+        is_third_party_typeshed_file: false,
+        is_local_typings_file: false,
+        implicit_imports: ImplicitImports(
+            {},
+        ),
+        filtered_implicit_imports: ImplicitImports(
+            {},
+        ),
+        non_stub_import_result: None,
+        py_typed_info: None,
+        package_directory: None,
+    },
+}
+os.path
+- Declarations:
+--:   Alias {
+    declaration_path: DeclarationPath {
+        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.imports.py",
+        node: Node {
+            start: 69,
+            end: 76,
+        },
+    },
+    import_from_node: None,
+    import_node: Some(
+        Import {
+            node: Node {
+                start: 62,
+                end: 76,
+            },
+            names: [
+                Alias {
+                    node: Node {
+                        start: 69,
+                        end: 76,
+                    },
+                    name: "os.path",
+                    asname: None,
+                },
+            ],
+        },
+    ),
+    symbol_name: None,
+    import_result: ImportResult {
+        is_relative: false,
+        is_import_found: false,
+        is_partly_resolved: false,
+        is_namespace_package: false,
+        is_init_file_present: false,
+        is_stub_package: false,
+        import_type: Local,
+        resolved_paths: [],
+        search_path: None,
+        is_stub_file: false,
+        is_native_lib: false,
+        is_stdlib_typeshed_file: false,
+        is_third_party_typeshed_file: false,
+        is_local_typings_file: false,
+        implicit_imports: ImplicitImports(
+            {},
+        ),
+        filtered_implicit_imports: ImplicitImports(
+            {},
+        ),
+        non_stub_import_result: None,
+        py_typed_info: None,
+        package_directory: None,
+    },
+}
 variables
 - Declarations:
 --:   Alias {
@@ -115,14 +259,26 @@ variables
             end: 16,
         },
     },
-    alias_node: Alias {
-        node: Node {
-            start: 7,
-            end: 16,
+    import_from_node: None,
+    import_node: Some(
+        Import {
+            node: Node {
+                start: 0,
+                end: 16,
+            },
+            names: [
+                Alias {
+                    node: Node {
+                        start: 7,
+                        end: 16,
+                    },
+                    name: "variables",
+                    asname: None,
+                },
+            ],
         },
-        name: "variables",
-        asname: None,
-    },
+    ),
+    symbol_name: None,
     import_result: ImportResult {
         is_relative: false,
         is_import_found: true,

--- a/typechecker/testdata/output/enderpy_python_type_checker__build__tests__symbol_table@simple_var_assignment.py.snap
+++ b/typechecker/testdata/output/enderpy_python_type_checker__build__tests__symbol_table@simple_var_assignment.py.snap
@@ -11,7 +11,7 @@ a
 - Declarations:
 --:   Variable {
     declaration_path: DeclarationPath {
-        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.simple_var_assignment.py",
+        module_name: [REDACTED]",
         node: Node {
             start: 0,
             end: 17,
@@ -36,7 +36,7 @@ b
 - Declarations:
 --:   Variable {
     declaration_path: DeclarationPath {
-        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.simple_var_assignment.py",
+        module_name: [REDACTED]",
         node: Node {
             start: 18,
             end: 29,
@@ -79,7 +79,7 @@ c
 - Declarations:
 --:   Variable {
     declaration_path: DeclarationPath {
-        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.simple_var_assignment.py",
+        module_name: [REDACTED]",
         node: Node {
             start: 31,
             end: 41,
@@ -114,7 +114,7 @@ f
 - Declarations:
 --:   Variable {
     declaration_path: DeclarationPath {
-        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.simple_var_assignment.py",
+        module_name: [REDACTED]",
         node: Node {
             start: 43,
             end: 59,

--- a/typechecker/testdata/output/enderpy_python_type_checker__build__tests__symbol_table@simple_var_assignment.py.snap
+++ b/typechecker/testdata/output/enderpy_python_type_checker__build__tests__symbol_table@simple_var_assignment.py.snap
@@ -9,16 +9,142 @@ global scope:
 Symbols:
 a
 - Declarations:
---:   Variable { declaration_path: DeclarationPath { module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.simple_var_assignment.py", node: Node { start: 0, end: 17 } }, scope: Global, type_annotation: None, inferred_type_source: Some(Constant(Constant { node: Node { start: 4, end: 17 }, value: "hello world" })), is_constant: false }
+--:   Variable {
+    declaration_path: DeclarationPath {
+        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.simple_var_assignment.py",
+        node: Node {
+            start: 0,
+            end: 17,
+        },
+    },
+    scope: Global,
+    type_annotation: None,
+    inferred_type_source: Some(
+        Constant(
+            Constant {
+                node: Node {
+                    start: 4,
+                    end: 17,
+                },
+                value: "hello world",
+            },
+        ),
+    ),
+    is_constant: false,
+}
 b
 - Declarations:
---:   Variable { declaration_path: DeclarationPath { module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.simple_var_assignment.py", node: Node { start: 18, end: 29 } }, scope: Global, type_annotation: None, inferred_type_source: Some(BinOp(BinOp { node: Node { start: 22, end: 29 }, op: Add, left: Name(Name { node: Node { start: 22, end: 23 }, id: "a" }), right: Constant(Constant { node: Node { start: 26, end: 29 }, value: "!" }) })), is_constant: false }
+--:   Variable {
+    declaration_path: DeclarationPath {
+        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.simple_var_assignment.py",
+        node: Node {
+            start: 18,
+            end: 29,
+        },
+    },
+    scope: Global,
+    type_annotation: None,
+    inferred_type_source: Some(
+        BinOp(
+            BinOp {
+                node: Node {
+                    start: 22,
+                    end: 29,
+                },
+                op: Add,
+                left: Name(
+                    Name {
+                        node: Node {
+                            start: 22,
+                            end: 23,
+                        },
+                        id: "a",
+                    },
+                ),
+                right: Constant(
+                    Constant {
+                        node: Node {
+                            start: 26,
+                            end: 29,
+                        },
+                        value: "!",
+                    },
+                ),
+            },
+        ),
+    ),
+    is_constant: false,
+}
 c
 - Declarations:
---:   Variable { declaration_path: DeclarationPath { module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.simple_var_assignment.py", node: Node { start: 31, end: 41 } }, scope: Global, type_annotation: Some(Name(Name { node: Node { start: 34, end: 37 }, id: "int" })), inferred_type_source: Some(Constant(Constant { node: Node { start: 40, end: 41 }, value: 1 })), is_constant: false }
+--:   Variable {
+    declaration_path: DeclarationPath {
+        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.simple_var_assignment.py",
+        node: Node {
+            start: 31,
+            end: 41,
+        },
+    },
+    scope: Global,
+    type_annotation: Some(
+        Name(
+            Name {
+                node: Node {
+                    start: 34,
+                    end: 37,
+                },
+                id: "int",
+            },
+        ),
+    ),
+    inferred_type_source: Some(
+        Constant(
+            Constant {
+                node: Node {
+                    start: 40,
+                    end: 41,
+                },
+                value: 1,
+            },
+        ),
+    ),
+    is_constant: false,
+}
 f
 - Declarations:
---:   Variable { declaration_path: DeclarationPath { module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.simple_var_assignment.py", node: Node { start: 43, end: 59 } }, scope: Global, type_annotation: Some(Name(Name { node: Node { start: 46, end: 49 }, id: "str" })), inferred_type_source: Some(Constant(Constant { node: Node { start: 52, end: 59 }, value: "hello" })), is_constant: false }
+--:   Variable {
+    declaration_path: DeclarationPath {
+        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.simple_var_assignment.py",
+        node: Node {
+            start: 43,
+            end: 59,
+        },
+    },
+    scope: Global,
+    type_annotation: Some(
+        Name(
+            Name {
+                node: Node {
+                    start: 46,
+                    end: 49,
+                },
+                id: "str",
+            },
+        ),
+    ),
+    inferred_type_source: Some(
+        Constant(
+            Constant {
+                node: Node {
+                    start: 52,
+                    end: 59,
+                },
+                value: "hello",
+            },
+        ),
+    ),
+    is_constant: false,
+}
 
 all scopes:
 -------------------

--- a/typechecker/testdata/output/enderpy_python_type_checker__build__tests__symbol_table@variables.py.snap
+++ b/typechecker/testdata/output/enderpy_python_type_checker__build__tests__symbol_table@variables.py.snap
@@ -9,7 +9,29 @@ global scope:
 Symbols:
 a
 - Declarations:
---:   Variable { declaration_path: DeclarationPath { module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.variables.py", node: Node { start: 0, end: 5 } }, scope: Global, type_annotation: None, inferred_type_source: Some(Constant(Constant { node: Node { start: 4, end: 5 }, value: 1 })), is_constant: false }
+--:   Variable {
+    declaration_path: DeclarationPath {
+        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.variables.py",
+        node: Node {
+            start: 0,
+            end: 5,
+        },
+    },
+    scope: Global,
+    type_annotation: None,
+    inferred_type_source: Some(
+        Constant(
+            Constant {
+                node: Node {
+                    start: 4,
+                    end: 5,
+                },
+                value: 1,
+            },
+        ),
+    ),
+    is_constant: false,
+}
 
 all scopes:
 -------------------

--- a/typechecker/testdata/output/enderpy_python_type_checker__build__tests__symbol_table@variables.py.snap
+++ b/typechecker/testdata/output/enderpy_python_type_checker__build__tests__symbol_table@variables.py.snap
@@ -11,7 +11,7 @@ a
 - Declarations:
 --:   Variable {
     declaration_path: DeclarationPath {
-        module_name: ".Users.glyphack.Programming.enderpy.typechecker.test_data.inputs.symbol_table.variables.py",
+        module_name: [REDACTED]",
         node: Node {
             start: 0,
             end: 5,


### PR DESCRIPTION
- Add import from statements to symbol table
- Update tests to pretty print import results

This is what we want to do for imports:

- import a: Adds an entry to the symbol table for the module a. The entry includes the module name and a flag indicating it is a module.
- from a import b: Adds an entry for b that points to the symbol b within the module a. The entry includes the symbol name, a flag indicating it is imported, and a reference to the module symbol a.
- from a import *: Adds an entry to symbol table with name *. This symbol table node will be used in another pass to actually copy the symbols from imported module in this table.